### PR TITLE
Add multi index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:        ## Install the package and dependencies in a venv
 	uv pip install -e .[api]
 
 run-api:        ## Run the api server
-	uv run python -m ragatouille.server.server --index_name .ragatouille/colbert/indexes/demo --reload
+	uv run python -m ragatouille.server.server --index-root  /Users/pau/development/taizen-rag/.ragatouille --experiment-name colbert --reload
 
 lint:   ## Run linters: ruff
 	uv run ruff check . --fix

--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,7 @@ Right now to adapt it to Taizen use we need:
  2. For the full workflow: The API workers would need to spin up a task. With only 1 worker we would then perform the search or index. (Maybe, since the worker is spinned up with parameters we can pass that to the worker and let each worker instantiate the index itself)
  3. We can wrap up the endpoints with batched for a better use of parallel resources. We have to be careful because requests would have to be split by project_id...
  4. Right now each index has to be manually created, we should provide an endpoint for that.
+
+ For training, remember:
+    # Jina uses query_prefix="[QueryMarker]"
+    # Jine uses document_prefix="[DocumentMarker]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "sentence-transformers",
     "setuptools",
     "einops",
-    "psutil"
+    "psutil",
+    "pytest>=8.4.0",
 ]
 
 [project.optional-dependencies]
@@ -45,8 +46,9 @@ all = [
     "fastapi >= 0.114.1",
     "uvicorn >= 0.30.6",
     "batched >= 0.1.2",
+    "pytest"
 ]
-api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2"]
+api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2", "pytest"]
 train = ["sentence-transformers", "pylate", "rerankers"]
 
 [project.urls]

--- a/ragatouille/models/base.py
+++ b/ragatouille/models/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Union
+from typing import Union, List, Optional, Dict, Any, Literal
 
 
 class LateInteractionModel(ABC):
@@ -8,30 +8,220 @@ class LateInteractionModel(ABC):
     def __init__(
         self,
         pretrained_model_name_or_path: Union[str, Path],
-        n_gpu,
+        index_root: Optional[str] = None,
+        n_gpu: int = -1,
+        verbose: int = 1,
+        initial_index_name: Optional[str] = None,
+        experiment_name: str = "colbert",
+        **kwargs: Any,
     ):
+        """
+        Initializes the late-interaction model.
+
+        Parameters:
+            pretrained_model_name_or_path: Path to a local checkpoint or Hugging Face model name.
+            index_root: The root directory where all named indices will be stored/loaded from.
+            n_gpu: Number of GPUs to use. -1 for all available.
+            verbose: Verbosity level.
+            initial_index_name: Optionally, the name of an index to load immediately.
+            experiment_name: Name of the experiment, used in structuring the index path.
+            **kwargs: Additional keyword arguments for model configuration.
+        """
         ...
 
     @abstractmethod
-    def train():
+    def index(
+        self,
+        index_name: str,
+        collection: List[str],
+        pid_docid_map: Dict[int, str],
+        docid_metadata_map: Optional[Dict[str, Any]] = None,
+        max_document_length: int = 256,
+        overwrite: Union[bool, str] = "reuse",
+        bsize: int = 32,
+        use_faiss: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        """
+        Builds or updates an index for the given collection of passages.
+
+        Parameters:
+            index_name: The name of the index to build or update.
+            collection: List of passages/chunks to index.
+            pid_docid_map: Mapping from passage ID (0-indexed within collection) to original document ID.
+            docid_metadata_map: Optional mapping from original document ID to its metadata.
+            max_document_length: Maximum document length for configuring the index (e.g., doc_maxlen).
+            overwrite: Policy for overwriting if index exists.
+            bsize: Batch size for encoding passages.
+            use_faiss: Whether to use FAISS for the index backend (if applicable).
+            **kwargs: Additional keyword arguments for index-specific configuration.
+
+        Returns:
+            The path to the created or updated index.
+        """
         ...
 
     @abstractmethod
-    def index(self, name: str, collection: list[str]):
+    def add_to_index(
+        self,
+        index_name: str,
+        new_documents: List[str],
+        new_pid_docid_map_for_new_docs: Dict[int, str],
+        new_docid_metadata_map: Optional[Dict[str, Any]] = None,
+        bsize: int = 32,
+        use_faiss: bool = False,
+    ) -> None:
+        """
+        Adds new passages to an existing index.
+
+        Parameters:
+            index_name: The name of the index to add to.
+            new_documents: List of new passages/chunks to add.
+            new_pid_docid_map_for_new_docs: Mapping for the new passages (0-indexed for new_documents)
+                                             to their original document IDs.
+            new_docid_metadata_map: Optional metadata for original document IDs corresponding to new_documents.
+            bsize: Batch size for encoding new passages.
+            use_faiss: Whether to use FAISS if the add operation triggers a rebuild.
+        """
         ...
 
     @abstractmethod
-    def add_to_index(self):
+    def delete_from_index(
+        self,
+        index_name: str,
+        document_ids: Union[str, List[str]],
+    ) -> None:
+        """
+        Deletes documents (and all their associated passages) from a specified index.
+
+        Parameters:
+            index_name: The name of the index from which to delete.
+            document_ids: A single original document ID or a list of original document IDs to delete.
+        """
         ...
 
     @abstractmethod
-    def search(self, name: str, query: Union[str, list[str]]):
+    def search(
+        self,
+        index_name: str,
+        query: Union[str, List[str]],
+        k: int = 10,
+        force_fast: bool = False,
+        zero_index_ranks: bool = False,
+        doc_ids: Optional[List[str]] = None,
+    ) -> Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]:
+        """
+        Searches an index for a given query or list of queries.
+
+        Parameters:
+            index_name: The name of the index to search.
+            query: The query string or list of query strings.
+            k: The number of results to return per query.
+            force_fast: Use faster, potentially less accurate search settings.
+            zero_index_ranks: If True, ranks are 0-indexed. Otherwise 1-indexed.
+            doc_ids: Optional list of original document IDs to restrict the search to.
+
+        Returns:
+            A list of result dictionaries for a single query, or a list of lists of
+            result dictionaries for multiple queries.
+        """
         ...
 
     @abstractmethod
-    def _search(self, name: str, query: str):
+    def train(
+        self,
+        index_name_for_config: Optional[str],
+        data_dir: Union[str, Path],
+        training_config_overrides: Dict[str, Any],
+    ) -> str:
+        """
+        Trains the model.
+
+        Parameters:
+            index_name_for_config: Optional name of an existing index to use its configuration as a base.
+            data_dir: Path to the directory containing training data (triples, queries, corpus).
+            training_config_overrides: Dictionary of parameters to override in the model's training configuration.
+
+        Returns:
+            Path to the best trained checkpoint.
+        """
         ...
 
     @abstractmethod
-    def _batch_search(self, name: str, queries: list[str]):
+    def rank(
+        self,
+        query: str,
+        documents: List[str],
+        k: int = 10,
+        zero_index_ranks: bool = False,
+        bsize: Union[Literal["auto"], int] = "auto",
+        max_tokens: Union[Literal["auto"], int] = "auto",
+    ) -> List[Dict[str, Any]]:
+        """
+        Reranks a list of documents in-memory for a given query without using a disk-based index.
+
+        Parameters:
+            query: The query string.
+            documents: A list of document contents (passages) to rerank.
+            k: The number of top documents to return.
+            zero_index_ranks: If True, ranks are 0-indexed.
+            bsize: Batch size for encoding.
+            max_tokens: Max tokens for document encoding. 'auto' adjusts based on content.
+
+        Returns:
+            A list of reranked result dictionaries.
+        """
+        ...
+
+    @abstractmethod
+    def encode(
+        self,
+        documents: List[str],
+        document_metadatas: Optional[List[Optional[Dict[str, Any]]]] = None,
+        bsize: int = 32,
+        max_tokens: Union[Literal["auto"], int] = "auto",
+        verbose_override: Optional[bool] = None,
+    ) -> None:
+        """
+        Encodes documents and caches their embeddings in memory.
+
+        Parameters:
+            documents: List of document contents to encode.
+            document_metadatas: Optional list of metadata dicts, matched to documents.
+            bsize: Batch size for encoding.
+            max_tokens: Max tokens for document encoding. 'auto' adjusts based on content.
+            verbose_override: Override instance verbosity for this call.
+        """
+        ...
+
+    @abstractmethod
+    def search_encoded_docs(
+        self,
+        queries: Union[str, List[str]],
+        k: int = 10,
+        bsize: int = 32,
+        zero_index_ranks: bool = False,
+    ) -> Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]:
+        """
+        Searches through documents previously encoded and cached in memory via `encode()`.
+
+        Parameters:
+            queries: The query string or list of query strings.
+            k: The number of results to return per query.
+            bsize: Batch size for query encoding.
+            zero_index_ranks: If True, ranks are 0-indexed.
+
+        Returns:
+            Search results, similar to the `search` method for indexed data.
+        """
+        ...
+
+    @abstractmethod
+    def clear_encoded_docs(self, force: bool = False) -> None:
+        """
+        Clears any documents and their embeddings cached in memory by `encode()`.
+
+        Parameters:
+            force: If True, clears without a confirmation delay.
+        """
         ...

--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -3,7 +3,7 @@ import os
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, TypeVar, Union
+from typing import Dict, List, Literal, Optional, TypeVar, Union, Any
 
 import numpy as np
 import srsly
@@ -22,439 +22,618 @@ class ColBERT(LateInteractionModel):
     def __init__(
         self,
         pretrained_model_name_or_path: Union[str, Path],
-        n_gpu: int = -1,
-        index_name: Optional[str] = None,
-        verbose: int = 1,
-        load_from_index: bool = False,
-        training_mode: bool = False,
         index_root: Optional[str] = None,
-        **kwargs,
+        n_gpu: int = -1,
+        verbose: int = 1,
+        initial_index_name: Optional[str] = None,
+        experiment_name: str = "colbert", # Default experiment name
+        **kwargs, # Catch-all for other ColBERTConfig settings for new indices
     ):
         self.verbose = verbose
-        self.collection = None
-        self.pid_docid_map = None
-        self.docid_pid_map = None
-        self.docid_metadata_map = None
-        self.base_model_max_tokens = 510
+        self.base_pretrained_model_name_or_path = pretrained_model_name_or_path
+        self.index_root = index_root if index_root is not None else ".ragatouille/"
+        self.experiment_name = experiment_name
+
+        self.base_model_max_tokens = 510 # Default, will be updated after model load
+
         if n_gpu == -1:
             n_gpu = 1 if torch.cuda.device_count() == 0 else torch.cuda.device_count()
 
-        self.loaded_from_index = load_from_index
+        # Multi-index storage
+        self.collections: Dict[str, List[str]] = {}
+        self.pid_docid_maps: Dict[str, Dict[int, str]] = {}
+        self.docid_pid_maps: Dict[str, Dict[str, List[int]]] = {}
+        self.docid_metadata_maps: Dict[str, Optional[Dict[str, Any]]] = {}
+        self.model_indices: Dict[str, Optional[ModelIndex]] = {}
+        self.index_configs: Dict[str, ColBERTConfig] = {} # Stores specific config for each index
+        self.index_paths: Dict[str, str] = {} # Stores full path to each index directory
 
-        self.model_index: Optional[ModelIndex] = None
-        if load_from_index:
-            self.index_path = str(pretrained_model_name_or_path)
-            ckpt_config = ColBERTConfig.load_from_index(
-                str(pretrained_model_name_or_path)
-            )
-            self.model_index = ModelIndexFactory.load_from_file(
-                self.index_path, index_name, ckpt_config
-            )
-            self.config = self.model_index.config
-            self.run_config = RunConfig(
-                nranks=n_gpu, experiment=self.config.experiment, root=self.config.root
-            )
-            split_root = str(pretrained_model_name_or_path).split("/")[:-1]
-            self.config.root = "/".join(split_root)
-            self.index_root = self.config.root
-            self.checkpoint = self.config.checkpoint
-            self.index_name = self.config.index_name
-            self._get_collection_files_from_disk(pretrained_model_name_or_path)
-            # TODO: Modify root assignment when loading from HF
+        # Load base model configuration
+        # For new indices, this base_config will be the starting point
+        self.base_model_config = ColBERTConfig.load_from_checkpoint(
+            str(pretrained_model_name_or_path),
+            **kwargs # Pass other ColBERTConfig settings
+        )
+        self.base_model_config.root = str(Path(self.index_root) / self.experiment_name / "indexes")
+        self.base_model_config.experiment = self.experiment_name
 
-        else:
-            self.index_root = index_root if index_root is not None else ".ragatouille/"
-            ckpt_config = ColBERTConfig.load_from_checkpoint(
-                str(pretrained_model_name_or_path)
-            )
-            self.run_config = RunConfig(
-                nranks=n_gpu, experiment="colbert", root=self.index_root
-            )
-            local_config = ColBERTConfig(**kwargs)
-            self.config = ColBERTConfig.from_existing(
-                ckpt_config,
-                local_config,
-            )
-            self.checkpoint = pretrained_model_name_or_path
-            self.index_name = index_name
-            self.config.experiment = "colbert"
-            self.config.root = self.index_root
 
-        if not training_mode:
-            self.inference_ckpt = Checkpoint(
-                self.checkpoint, colbert_config=self.config
-            )
-            self.base_model_max_tokens = (
-                self.inference_ckpt.bert.config.max_position_embeddings
-            ) - 4
+        # Global RunConfig for the underlying ColBERT model
+        self.run_config = RunConfig(
+            nranks=n_gpu, experiment=self.experiment_name, root=self.index_root
+        )
+
+        # Load the actual inference model weights (once)
+        self.inference_ckpt = Checkpoint(
+            str(self.base_pretrained_model_name_or_path), colbert_config=self.base_model_config
+        )
+        self.base_model_max_tokens = (
+            self.inference_ckpt.bert.config.max_position_embeddings
+        ) - 4 # Standard adjustment
 
         self.run_context = Run().context(self.run_config)
         self.run_context.__enter__()  # Manually enter the context
-        self.searcher = None
 
-    def _invert_pid_docid_map(self) -> Dict[str, List[int]]:
+        if initial_index_name:
+            if not self.index_root:
+                raise ValueError("index_root must be provided if initial_index_name is set.")
+            try:
+                self._get_or_load_index_context(initial_index_name, create_if_not_exists=False)
+                if self.verbose > 0:
+                    print(f"Successfully loaded initial index '{initial_index_name}'.")
+            except FileNotFoundError:
+                if self.verbose > 0:
+                    print(f"Initial index '{initial_index_name}' not found at expected location. It will need to be created via .index() method.")
+            except Exception as e:
+                if self.verbose > 0:
+                    print(f"Failed to load initial index '{initial_index_name}': {e}")
+
+
+    def _get_index_path(self, index_name: str) -> str:
+        return str(
+            Path(self.index_root)
+            / Path(self.experiment_name)
+            / "indexes"
+            / index_name
+        )
+
+    def _get_or_load_index_context(self, index_name: str, create_if_not_exists: bool = False, config_overrides: Optional[Dict[str, Any]] = None) -> ColBERTConfig:
+        if index_name in self.index_configs:
+            return self.index_configs[index_name]
+
+        current_index_path = self._get_index_path(index_name)
+        self.index_paths[index_name] = current_index_path
+
+        # Determine the root for this specific index's config
+        # This root is where ColBERT will look for subdirectories like `plan/` or `ivf/` for the index
+        specific_index_config_root = str(Path(self.index_root) / self.experiment_name / "indexes")
+
+        if os.path.exists(Path(current_index_path) / "metadata.json"):
+            # Index exists, load its specific configuration and data
+            if self.verbose > 0:
+                print(f"Loading existing index context for '{index_name}' from {current_index_path}")
+
+            # Load the ColBERTConfig specific to this index from its metadata.json
+            # This config might have different `doc_maxlen`, `nbits`, etc.
+            loaded_config = ColBERTConfig.load_from_index(current_index_path)
+
+            # Ensure its root and experiment are set correctly for operations
+            loaded_config.root = specific_index_config_root
+            loaded_config.experiment = self.experiment_name
+            loaded_config.index_name = index_name # Ensure index_name is part of its config
+
+            self.index_configs[index_name] = loaded_config
+
+            self.model_indices[index_name] = ModelIndexFactory.load_from_file(
+                current_index_path, index_name, loaded_config, verbose=self.verbose > 0
+            )
+            self._get_collection_files_from_disk(index_name, current_index_path)
+            return loaded_config
+        elif create_if_not_exists:
+            if self.verbose > 0:
+                print(f"Creating new index context for '{index_name}' at {current_index_path}")
+            # Index does not exist, create new context (typically during .index() call)
+            # Start with a copy of the base model config, then apply overrides
+            new_config = ColBERTConfig.from_existing(self.base_model_config, ColBERTConfig(**(config_overrides or {})))
+            new_config.root = specific_index_config_root
+            new_config.experiment = self.experiment_name
+            new_config.index_name = index_name # Important for operations
+
+            self.index_configs[index_name] = new_config
+            self.collections[index_name] = []
+            self.pid_docid_maps[index_name] = {}
+            self.docid_pid_maps[index_name] = defaultdict(list)
+            self.docid_metadata_maps[index_name] = None
+            self.model_indices[index_name] = None # Will be created by .index()
+            return new_config
+        else:
+            raise FileNotFoundError(f"Index '{index_name}' not found at {current_index_path} and create_if_not_exists is False.")
+
+    def _invert_pid_docid_map(self, index_name: str) -> Dict[str, List[int]]:
         d = defaultdict(list)
-        for k, v in self.pid_docid_map.items():
+        if index_name not in self.pid_docid_maps:
+             if self.verbose > 0:
+                print(f"Warning: pid_docid_map not found for index '{index_name}' during inversion.")
+             return d
+        for k, v in self.pid_docid_maps[index_name].items():
             d[v].append(k)
         return d
 
-    def _get_collection_files_from_disk(self, index_path: str):
-        self.collection = srsly.read_json(index_path / "collection.json")
-        if os.path.exists(str(index_path / "docid_metadata_map.json")):
-            self.docid_metadata_map = srsly.read_json(
-                str(index_path / "docid_metadata_map.json")
+    def _get_collection_files_from_disk(self, index_name: str, index_path_str: str):
+        index_path = Path(index_path_str)
+        self.collections[index_name] = srsly.read_json(index_path / "collection.json")
+
+        if os.path.exists(index_path / "docid_metadata_map.json"):
+            self.docid_metadata_maps[index_name] = srsly.read_json(
+                index_path / "docid_metadata_map.json"
             )
         else:
-            self.docid_metadata_map = None
+            self.docid_metadata_maps[index_name] = None
 
         try:
-            self.pid_docid_map = srsly.read_json(str(index_path / "pid_docid_map.json"))
+            pid_docid_map_data = srsly.read_json(index_path / "pid_docid_map.json")
         except FileNotFoundError as err:
             raise FileNotFoundError(
-                "ERROR: Could not load pid_docid_map from index!",
-                "This is likely because you are loading an older, incompatible index.",
+                f"ERROR: Could not load pid_docid_map.json for index '{index_name}' from {index_path}!",
+                "This is likely because you are loading an older, incompatible index or the index is corrupted.",
             ) from err
 
-        # convert all keys to int when loading from file because saving converts to str
-        self.pid_docid_map = {
-            int(key): value for key, value in self.pid_docid_map.items()
+        self.pid_docid_maps[index_name] = {
+            int(key): value for key, value in pid_docid_map_data.items()
         }
-        self.docid_pid_map = self._invert_pid_docid_map()
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
 
-    def add_to_index(
-        self,
-        new_documents: List[str],
-        new_pid_docid_map: Dict[int, str],
-        new_docid_metadata_map: Optional[List[dict]] = None,
-        index_name: Optional[str] = None,
-        bsize: int = 32,
-        use_faiss: bool = False,
-    ):
-        self.index_name = index_name if index_name is not None else self.index_name
-        if self.index_name is None:
-            print(
-                "Cannot add to index without an index_name! Please provide one.",
-                "Returning empty results.",
-            )
-            return None
+    def _write_collection_files_to_disk(self, index_name: str):
+        if index_name not in self.index_paths:
+            raise ValueError(f"Index path for '{index_name}' not found. Ensure index is initialized.")
+        current_index_path = self.index_paths[index_name]
 
-        print(
-            "WARNING: add_to_index support is currently experimental!",
-            "add_to_index support will be more thorough in future versions",
-        )
+        os.makedirs(current_index_path, exist_ok=True)
 
-        if self.loaded_from_index:
-            index_root = self.config.root
-        else:
-            expected_path_segment = Path(self.config.experiment) / "indexes"
-            if str(expected_path_segment) in self.config.root:
-                index_root = self.config.root
-            else:
-                index_root = str(Path(self.config.root) / expected_path_segment)
-
-            if not self.collection:
-                collection_path = Path(index_root) / self.index_name / "collection.json"
-                if collection_path.exists():
-                    self._get_collection_files_from_disk(
-                        str(Path(index_root) / self.index_name)
-                    )
-
-        pid_values = set(self.pid_docid_map.values())
-        new_documents_with_ids = [
-            {"content": doc, "document_id": new_pid_docid_map[pid]} 
-            for pid, doc in enumerate(new_documents)
-            if new_pid_docid_map[pid] not in pid_values
-        ]
-        
-        max_existing_pid = max(self.pid_docid_map.keys(), default=-1)
-        for idx, doc in enumerate(new_documents_with_ids, start=max_existing_pid + 1):
-            self.pid_docid_map[idx] = doc["document_id"]
-
-        new_collection = [doc["content"] for doc in new_documents_with_ids]
-
-        # TODO We may want to load an existing index here instead;
-        #      For now require that either index() was called, or an existing one was loaded.
-        assert self.model_index is not None
-
-        # TODO We probably want to store some of this in the model_index directly.
-        self.model_index.add(
-            self.config,
-            self.checkpoint,
-            self.collection,
-            index_root,
-            self.index_name,
-            new_collection,
-            verbose=self.verbose != 0,
-            bsize=bsize,
-            use_faiss=use_faiss,
-        )
-        self.config = self.model_index.config
-
-        # Update and serialize the index metadata + collection.
-        self.collection = self.collection + new_collection
-
-        # TODO This has inconsistent behavior for duplicates.
-        if new_docid_metadata_map is not None:
-            self.docid_metadata_map = self.docid_metadata_map or defaultdict(
-                lambda: None
-            )
-            self.docid_metadata_map.update(new_docid_metadata_map)
-
-        self.docid_pid_map = defaultdict(list)
-        for pid, docid in self.pid_docid_map.items():
-            self.docid_pid_map[docid].append(pid)
-
-        self._save_index_metadata()
-
-        print(
-            f"Successfully updated index with {len(new_documents_with_ids)} new documents!\n",
-            f"New index size: {len(self.collection)}",
-        )
-
-    def delete_from_index(
-        self,
-        document_ids: Union[TypeVar("T"), List[TypeVar("T")]],
-        index_name: Optional[str] = None,
-    ):
-        self.index_name = index_name if index_name is not None else self.index_name
-        if self.index_name is None:
-            print(
-                "Cannot delete from index without an index_name! Please provide one.",
-                "Returning empty results.",
-            )
-            return None
-
-        print(
-            "WARNING: delete_from_index support is currently experimental!",
-            "delete_from_index support will be more thorough in future versions",
-        )
-
-        pids_to_remove = []
-        for pid, docid in self.pid_docid_map.items():
-            if docid in document_ids:
-                pids_to_remove.append(pid)
-
-        # TODO We may want to load an existing index here instead;
-        #      For now require that either index() was called, or an existing one was loaded.
-        assert self.model_index is not None
-
-        # TODO We probably want to store some of this in the model_index directly.
-        self.model_index.delete(
-            self.config,
-            self.checkpoint,
-            self.collection,
-            self.index_name,
-            pids_to_remove,
-            verbose=self.verbose != 0,
-        )
-
-        # Update and serialize the index metadata + collection.
-        self.collection = [
-            doc for pid, doc in enumerate(self.collection) if pid not in pids_to_remove
-        ]
-        self.pid_docid_map = {
-            pid: docid
-            for pid, docid in self.pid_docid_map.items()
-            if pid not in pids_to_remove
-        }
-
-        if self.docid_metadata_map is not None:
-            self.docid_metadata_map = {
-                docid: metadata
-                for docid, metadata in self.docid_metadata_map.items()
-                if docid not in document_ids
-            }
-
-        self._save_index_metadata()
-
-        print(f"Successfully deleted documents with these IDs: {document_ids}")
-
-    def _write_collection_files_to_disk(self):
-        srsly.write_json(self.index_path + "/collection.json", self.collection)
-        srsly.write_json(self.index_path + "/pid_docid_map.json", self.pid_docid_map)
-        if self.docid_metadata_map is not None:
+        srsly.write_json(Path(current_index_path) / "collection.json", self.collections.get(index_name, []))
+        srsly.write_json(Path(current_index_path) / "pid_docid_map.json", self.pid_docid_maps.get(index_name, {}))
+        if self.docid_metadata_maps.get(index_name) is not None:
             srsly.write_json(
-                self.index_path + "/docid_metadata_map.json", self.docid_metadata_map
+                Path(current_index_path) / "docid_metadata_map.json", self.docid_metadata_maps[index_name]
             )
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
 
-        # update the in-memory inverted map every time the files are saved to disk
-        self.docid_pid_map = self._invert_pid_docid_map()
 
-    def _save_index_metadata(self):
-        assert self.model_index is not None
+    def _save_index_metadata(self, index_name: str):
+        config = self._get_or_load_index_context(index_name)
+        model_index = self.model_indices.get(index_name)
+        if model_index is None:
+            # This can happen if _save_index_metadata is called before ModelIndex is fully constructed (e.g. during .index())
+            # In such cases, the ModelIndex construction itself will save its metadata.
+            # However, if we are updating metadata for an *existing* model_index, it must be present.
+            # Let's check if the index path exists, implying a ModelIndex should have been loaded or is being built.
+            if not os.path.exists(self.index_paths[index_name]):
+                 raise ValueError(f"ModelIndex for '{index_name}' not found. Cannot save metadata.")
+            if self.verbose > 0:
+                print(f"ModelIndex for '{index_name}' not yet available for metadata export, assuming it will be handled by ModelIndex.construct.")
+            # We still need to save RAGatouille specific files if they exist
+            self._write_collection_files_to_disk(index_name)
+            return
 
-        model_metadata = srsly.read_json(self.index_path + "/metadata.json")
-        index_config = self.model_index.export_metadata()
-        index_config["index_name"] = self.index_name
-        # Ensure that the additional metadata we store does not collide with anything else.
-        model_metadata["RAGatouille"] = {"index_config": index_config}  # type: ignore
-        srsly.write_json(self.index_path + "/metadata.json", model_metadata)
-        self._write_collection_files_to_disk()
+
+        current_index_path = self.index_paths[index_name]
+        os.makedirs(current_index_path, exist_ok=True) # Ensure directory exists
+
+        metadata_file_path = Path(current_index_path) / "metadata.json"
+
+        model_metadata = {}
+        if metadata_file_path.exists():
+            try:
+                model_metadata = srsly.read_json(str(metadata_file_path))
+            except ValueError: # Handles empty or malformed JSON
+                if self.verbose > 0:
+                    print(f"Warning: metadata.json for index '{index_name}' was malformed or empty. Creating a new one.")
+                model_metadata = {}
+
+
+        index_specific_config = model_index.export_metadata()
+        index_specific_config["index_name"] = index_name # Ensure index_name is part of the stored metadata
+
+        # Merge ColBERTConfig parameters into the RAGatouille specific metadata for completeness
+        # These are parameters like nbits, doc_maxlen etc. specific to this index
+
+        # Explicitly list relevant, serializable ColBERTConfig fields to store.
+        # This avoids trying to serialize complex objects or functions that might be part of ColBERTConfig's internal state.
+        relevant_colbert_config_fields = [
+            "nbits",
+            "doc_maxlen",
+            "query_maxlen",
+            "index_bsize",
+            "kmeans_niters",
+            "gpus", # Number of GPUs used for this index creation/config
+            "bsize", # General batch size, distinct from index_bsize
+            "similarity", # e.g., 'cosine' or 'l2'
+            # Add other simple, serializable config fields as deemed necessary
+            # Be cautious not to include fields that are functions, complex objects,
+            # or already managed (like root, experiment, index_name, checkpoint).
+        ]
+        config_to_store = {}
+        for field_name in relevant_colbert_config_fields:
+            if hasattr(config, field_name):
+                config_to_store[field_name] = getattr(config, field_name)
+
+        ragatouille_metadata = {
+            "index_config": index_specific_config, # From ModelIndex.export_metadata()
+            "colbert_config_params": config_to_store,
+        }
+
+        model_metadata["RAGatouille"] = ragatouille_metadata
+        srsly.write_json(str(metadata_file_path), model_metadata)
+        self._write_collection_files_to_disk(index_name)
+
 
     def index(
         self,
+        index_name: str,
         collection: List[str],
         pid_docid_map: Dict[int, str],
         docid_metadata_map: Optional[dict] = None,
-        index_name: Optional["str"] = None,
         max_document_length: int = 256,
         overwrite: Union[bool, str] = "reuse",
         bsize: int = 32,
         use_faiss: bool = False,
+        **kwargs, # For additional ColBERTConfig settings for this specific index
     ):
-        self.collection = collection
-        self.config.doc_maxlen = max_document_length
+        config_overrides = kwargs
+        config_overrides['doc_maxlen'] = max_document_length
+        config_overrides['index_bsize'] = bsize
+        # nbits is determined inside PLAIDModelIndex.build based on collection size
 
-        if index_name is not None:
-            if self.index_name is not None:
-                print(
-                    f"New index_name received!",
-                    f"Updating current index_name ({self.index_name}) to {index_name}",
-                )
-            self.index_name = index_name
-        else:
-            if self.index_name is None:
-                print(
-                    f"No index_name received!",
-                    f"Using default index_name ({self.checkpoint}_new_index)",
-                )
-            self.index_name = self.checkpoint + "new_index"
+        config = self._get_or_load_index_context(index_name, create_if_not_exists=True, config_overrides=config_overrides)
+        # config is now the specific config for index_name
 
-        self.index_path = str(
-            Path(self.run_config.root)
-            / Path(self.run_config.experiment)
-            / "indexes"
-            / self.index_name
-        )
-        self.config.root = str(
-            Path(self.run_config.root) / Path(self.run_config.experiment) / "indexes"
-        )
+        self.collections[index_name] = collection
+        self.pid_docid_maps[index_name] = pid_docid_map
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
+        self.docid_metadata_maps[index_name] = docid_metadata_map
 
-        self.pid_docid_map = pid_docid_map
+        # The ModelIndexFactory will use config.root, config.experiment, and index_name
+        # to determine the actual path for storing index files (e.g. IVF lists, centroids)
+        # config.root is already Path(self.index_root) / self.experiment_name / "indexes"
+        # So the factory will create files under config.root / index_name / ...
 
-        # inverted mapping for returning full docs
-        self.docid_pid_map = defaultdict(list)
-        for pid, docid in self.pid_docid_map.items():
-            self.docid_pid_map[docid].append(pid)
-
-        self.docid_metadata_map = docid_metadata_map
-
-        self.model_index = ModelIndexFactory.construct(
-            "PLAID",
-            self.config,
-            self.checkpoint,
-            self.collection,
-            self.index_name,
-            overwrite,
-            verbose=self.verbose != 0,
+        model_index_instance = ModelIndexFactory.construct(
+            index_type="PLAID", # Currently PLAID is the main supported type
+            config=config, # Pass the specific config for this index
+            checkpoint=str(self.base_pretrained_model_name_or_path),
+            collection=self.collections[index_name],
+            index_name=index_name, # This is crucial
+            overwrite=overwrite,
+            verbose=self.verbose > 0,
             bsize=bsize,
             use_faiss=use_faiss,
         )
-        self.config = self.model_index.config
-        self._save_index_metadata()
+        self.model_indices[index_name] = model_index_instance
+        # Update self.index_configs[index_name] with any modifications made by ModelIndexFactory (e.g. nbits)
+        self.index_configs[index_name] = model_index_instance.config
 
-        print("Done indexing!")
+        self._save_index_metadata(index_name)
 
-        return self.index_path
+        if self.verbose > 0:
+            print(f"Done indexing for index '{index_name}'!")
+        return self.index_paths[index_name]
+
+
+    def add_to_index(
+        self,
+        index_name: str,
+        new_documents: List[str], # These are chunks/passages
+        new_pid_docid_map_for_new_docs: Dict[int, str], # PIDs here are 0-indexed for new_documents
+        new_docid_metadata_map: Optional[Dict[str, Any]] = None, # Metadata for document_ids in new_documents
+        bsize: int = 32,
+        use_faiss: bool = False, # Relevant if index needs to be rebuilt
+    ):
+        config = self._get_or_load_index_context(index_name, create_if_not_exists=False)
+        # config.root is Path(self.index_root) / self.experiment_name / "indexes"
+        # The model_index will operate within its specific directory: config.root / index_name
+
+        if self.verbose > 0:
+            print(
+            f"WARNING: add_to_index support for index '{index_name}' is currently experimental!",
+            "add_to_index support will be more thorough in future versions",
+            )
+
+        current_collection = self.collections.get(index_name, [])
+        current_pid_docid_map = self.pid_docid_maps.get(index_name, {})
+        current_docid_metadata_map = self.docid_metadata_maps.get(index_name, defaultdict(lambda: None))
+
+        # Filter out documents whose document_ids are already present
+        # This assumes new_pid_docid_map_for_new_docs gives the final intended document_id for each new passage
+        existing_doc_ids_in_index = set(current_pid_docid_map.values())
+
+        truly_new_passages_with_original_pid = [] # Stores (original_pid_in_new_docs, passage_content)
+        for original_pid, passage_content in enumerate(new_documents):
+            doc_id_for_this_passage = new_pid_docid_map_for_new_docs.get(original_pid)
+            if doc_id_for_this_passage is None:
+                if self.verbose > 0:
+                    print(f"Warning: Original PID {original_pid} in new_documents not found in new_pid_docid_map_for_new_docs. Skipping.")
+                continue
+            if doc_id_for_this_passage not in existing_doc_ids_in_index:
+                truly_new_passages_with_original_pid.append((original_pid, passage_content, doc_id_for_this_passage))
+
+        if not truly_new_passages_with_original_pid:
+            if self.verbose > 0:
+                print(f"No new unique documents to add to index '{index_name}'. All provided document IDs already exist or no valid new documents provided.")
+            return
+
+        new_collection_for_indexer = [item[1] for item in truly_new_passages_with_original_pid]
+
+        # Update persistent maps
+        max_existing_pid = max(current_pid_docid_map.keys(), default=-1)
+        for idx, (original_pid, passage_content, doc_id_for_this_passage) in enumerate(truly_new_passages_with_original_pid):
+            new_global_pid = max_existing_pid + 1 + idx
+            current_pid_docid_map[new_global_pid] = doc_id_for_this_passage
+
+        current_collection.extend(new_collection_for_indexer)
+
+        if new_docid_metadata_map:
+            current_docid_metadata_map.update(new_docid_metadata_map)
+
+        self.collections[index_name] = current_collection
+        self.pid_docid_maps[index_name] = current_pid_docid_map
+        self.docid_metadata_maps[index_name] = current_docid_metadata_map
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
+
+        model_index = self.model_indices.get(index_name)
+        if model_index is None:
+            raise ValueError(f"ModelIndex for '{index_name}' not found. Cannot add to it. Has it been indexed first?")
+
+        model_index.add(
+            config=config, # Pass the specific config
+            checkpoint=str(self.base_pretrained_model_name_or_path),
+            collection=self.collections[index_name], # Pass the full current collection
+            index_root=config.root, # This is like Path(self.index_root) / self.experiment_name / "indexes"
+            index_name=index_name, # Crucial
+            new_collection=new_collection_for_indexer, # Only the truly new passages
+            verbose=self.verbose > 0,
+            bsize=bsize,
+            use_faiss=use_faiss, # For potential rebuild
+        )
+        self.index_configs[index_name] = model_index.config # Update with potentially modified config from .add()
+
+        self._save_index_metadata(index_name)
+
+        if self.verbose > 0:
+            print(
+                f"Successfully attempted to update index '{index_name}' with {len(new_collection_for_indexer)} new passages!\n",
+                f"New index size for '{index_name}': {len(self.collections[index_name])} passages.",
+            )
+
+
+    def delete_from_index(
+        self,
+        index_name: str,
+        document_ids: Union[TypeVar("T"), List[TypeVar("T")]], # Document IDs to remove
+    ):
+        config = self._get_or_load_index_context(index_name, create_if_not_exists=False)
+
+        if self.verbose > 0:
+            print(
+                f"WARNING: delete_from_index support for index '{index_name}' is currently experimental!",
+                "delete_from_index support will be more thorough in future versions",
+            )
+
+        current_collection = self.collections.get(index_name)
+        current_pid_docid_map = self.pid_docid_maps.get(index_name)
+        current_docid_metadata_map = self.docid_metadata_maps.get(index_name)
+
+        if not current_collection or not current_pid_docid_map:
+            if self.verbose > 0:
+                print(f"Index '{index_name}' appears to be empty or not loaded. Cannot delete.")
+            return
+
+        pids_to_remove_from_indexer = []
+        doc_ids_to_remove_set = set(document_ids if isinstance(document_ids, list) else [document_ids])
+
+        new_pid_docid_map = {}
+        kept_passage_indices = [] # 0-indexed relative to current_collection
+
+        # Iterate through current PIDs to find which ones to remove
+        # And construct the list of PIDs for the Indexer.remove() method
+        for pid_key, docid_val in current_pid_docid_map.items():
+            if docid_val in doc_ids_to_remove_set:
+                pids_to_remove_from_indexer.append(pid_key)
+            else:
+                # This passage is kept. We need its content for the new collection.
+                # The pid_key is its current global PID, which is also its index in current_collection.
+                # We need to map this old pid_key to a new pid_key if PIDs are compacted later.
+                # For now, just track which passages are kept.
+                # The indexer.remove() takes global PIDs.
+                pass # Handled by the model_index.delete itself based on pids_to_remove_from_indexer
+
+        if not pids_to_remove_from_indexer:
+            if self.verbose > 0:
+                print(f"No documents corresponding to the given IDs found in index '{index_name}'. Nothing to delete.")
+            return
+
+        model_index = self.model_indices.get(index_name)
+        if model_index is None:
+            raise ValueError(f"ModelIndex for '{index_name}' not found. Cannot delete. Has it been indexed first?")
+
+        model_index.delete(
+            config=config,
+            checkpoint=str(self.base_pretrained_model_name_or_path),
+            collection=current_collection, # Pass the full current collection
+            index_name=index_name,
+            pids_to_remove=pids_to_remove_from_indexer,
+            verbose=self.verbose > 0,
+        )
+        self.index_configs[index_name] = model_index.config
+
+
+        # After indexer has processed deletions, update our local high-level trackings
+        # Rebuild collections, pid_docid_maps, etc. based on what remains
+        # This is simpler than trying to surgically remove and re-index PIDs.
+        # The indexer internally handles tombstones or compaction.
+        # For our metadata, we effectively "reload" it reflecting the deletions.
+
+        # A bit inefficient, but safest: re-filter based on the pids *not* removed
+        new_collection_content = []
+        new_pid_to_docid = {}
+        next_new_pid = 0
+        for old_pid, passage_content in enumerate(current_collection):
+            if old_pid not in pids_to_remove_from_indexer: # If this passage was NOT deleted by indexer
+                new_collection_content.append(passage_content)
+                # Map its original document_id to the new PID
+                original_doc_id = current_pid_docid_map.get(old_pid)
+                if original_doc_id: # Should always exist
+                    new_pid_to_docid[next_new_pid] = original_doc_id
+                next_new_pid += 1
+
+        self.collections[index_name] = new_collection_content
+        self.pid_docid_maps[index_name] = new_pid_to_docid
+
+        if current_docid_metadata_map is not None:
+            self.docid_metadata_maps[index_name] = {
+                docid: metadata
+                for docid, metadata in current_docid_metadata_map.items()
+                if docid not in doc_ids_to_remove_set
+            }
+
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
+        self._save_index_metadata(index_name)
+
+        if self.verbose > 0:
+            print(f"Successfully deleted documents with IDs {doc_ids_to_remove_set} from index '{index_name}'.")
+            print(f"New index size for '{index_name}': {len(self.collections[index_name])} passages.")
+
 
     def search(
         self,
+        index_name: str,
         query: Union[str, list[str]],
-        index_name: Optional["str"] = None,
         k: int = 10,
         force_fast: bool = False,
         zero_index_ranks: bool = False,
-        doc_ids: Optional[List[str]] = None,
+        doc_ids: Optional[List[str]] = None, # Filter search to these document_ids
     ):
-        pids = None
+        print("1")
+        config = self._get_or_load_index_context(index_name, create_if_not_exists=False)
+        model_index = self.model_indices.get(index_name)
+        current_collection = self.collections.get(index_name)
+        current_pid_docid_map = self.pid_docid_maps.get(index_name)
+        current_docid_pid_map = self.docid_pid_maps.get(index_name)
+        current_docid_metadata_map = self.docid_metadata_maps.get(index_name)
+        print("2", current_pid_docid_map)
+
+        if model_index is None or not current_collection or not current_pid_docid_map or not current_docid_pid_map:
+            raise ValueError(f"Index '{index_name}' is not properly loaded or is empty. Cannot search.")
+        print("3")
+        pids_to_search_within = None
         if doc_ids is not None:
-            pids = []
-            for doc_id in doc_ids:
-                pids.extend(self.docid_pid_map[doc_id])
-
-        force_reload = index_name is not None and index_name != self.index_name
-        if index_name is not None:
-            if self.index_name is not None and self.index_name != index_name:
-                print(
-                    f"New index_name received!",
-                    f"Updating current index_name ({self.index_name}) to {index_name}",
-                )
-            self.index_name = index_name
-        else:
-            if self.index_name is None:
-                print(
-                    "Cannot search without an index_name! Please provide one.",
-                    "Returning empty results.",
-                )
-                return None
-
-        # TODO We may want to load an existing index here instead;
-        #      For now require that either index() was called, or an existing one was loaded.
-        assert self.model_index is not None
-
-        results = self.model_index.search(
-            self.config,
-            self.checkpoint,
-            self.collection,
-            self.index_name,
-            self.base_model_max_tokens,
-            query,
-            k,
-            pids,
-            force_reload,
+            pids_to_search_within = []
+            for doc_id_filter in doc_ids:
+                pids_to_search_within.extend(current_docid_pid_map.get(doc_id_filter, []))
+            if not pids_to_search_within:
+                if self.verbose > 0:
+                    print(f"Warning: doc_ids filter provided for index '{index_name}', but no passages found for these doc_ids. Returning empty results.")
+                return [] if isinstance(query, str) else [[] for _ in query]
+        print("4")
+        # The model_index search needs the full collection context if it's not already loaded by its Searcher
+        # However, PLAIDModelIndex typically loads its own collection view.
+        results_from_model_index = model_index.search(
+            config=config,
+            checkpoint=str(self.base_pretrained_model_name_or_path),
+            collection=current_collection, # Provided for context, Searcher might use its own view
+            index_name=index_name,
+            base_model_max_tokens=self.base_model_max_tokens,
+            query=query,
+            k=k,
+            pids=pids_to_search_within, # Pass the filtered PIDs to the searcher
+            force_reload=False, # We handle context loading; force_reload here is for searcher specific state.
             force_fast=force_fast,
         )
-
+        print("5")
         to_return = []
-        for result in results:
+        for result_group in results_from_model_index: # result_group is for one query
             result_for_query = []
-            for id_, rank, score in zip(*result):
-                document_id = self.pid_docid_map[id_]
+            # result_group is typically (passage_ids, ranks, scores)
+            passage_pids, ranks, scores = result_group[0], result_group[1], result_group[2]
+
+            for passage_pid, rank_val, score_val in zip(passage_pids, ranks, scores):
+                document_id_for_passage = current_pid_docid_map.get(int(passage_pid))
+                if document_id_for_passage is None:
+                    if self.verbose > 0:
+                        print(f"Warning: Passage PID {passage_pid} from search results not found in pid_docid_map for index '{index_name}'. Skipping.")
+                    continue
+
+                # Ensure passage_pid is valid index for current_collection
+                if not (0 <= int(passage_pid) < len(current_collection)):
+                    if self.verbose > 0:
+                        print(f"Warning: Passage PID {passage_pid} from search results is out of bounds for current_collection of index '{index_name}'. Skipping.")
+                    continue
+
+
                 result_dict = {
-                    "content": self.collection[id_],
-                    "score": score,
-                    "rank": rank - 1 if zero_index_ranks else rank,
-                    "document_id": document_id,
-                    "passage_id": id_,
+                    "content": current_collection[int(passage_pid)],
+                    "score": float(score_val),
+                    "rank": int(rank_val) - 1 if zero_index_ranks else int(rank_val),
+                    "document_id": document_id_for_passage,
+                    "passage_id": int(passage_pid), # This is the internal PID used by ColBERT
                 }
 
-                if self.docid_metadata_map is not None:
-                    if document_id in self.docid_metadata_map:
-                        doc_metadata = self.docid_metadata_map[document_id]
+                if current_docid_metadata_map is not None:
+                    if document_id_for_passage in current_docid_metadata_map:
+                        doc_metadata = current_docid_metadata_map[document_id_for_passage]
                         result_dict["document_metadata"] = doc_metadata
 
                 result_for_query.append(result_dict)
-
             to_return.append(result_for_query)
 
-        if len(to_return) == 1:
-            return to_return[0]
-        return to_return
+        return to_return[0] if isinstance(query, str) and len(to_return) == 1 else to_return
 
-    def _search(self, query: str, k: int, pids: Optional[List[int]] = None):
-        assert self.model_index is not None
-        return self.model_index._search(query, k, pids)
 
-    def _batch_search(self, query: list[str], k: int):
-        assert self.model_index is not None
-        return self.model_index._batch_search(query, k)
+    # Methods for index-free operations (rank, encode, search_encoded_docs)
+    # These operate on the base model and don't interact with specific disk-based indices.
+    # They use self.inference_ckpt directly.
 
-    def train(self, data_dir, training_config: ColBERTConfig):
-        training_config = ColBERTConfig.from_existing(self.config, training_config)
-        training_config.nway = 2
-        with Run().context(self.run_config):
-            trainer = Trainer(
-                triples=str(data_dir / "triples.train.colbert.jsonl"),
-                queries=str(data_dir / "queries.train.colbert.tsv"),
-                collection=str(data_dir / "corpus.train.colbert.tsv"),
-                config=training_config,
-            )
+    def _set_inference_max_tokens(
+        self, documents: list[str], max_tokens: Union[Literal["auto"], int] = "auto"
+    ):
+        # This state should be temporary per call for index-free, or managed if we cache encodings
+        if not hasattr(self, "_temp_inference_ckpt_len_set") or self._temp_inference_ckpt_len_set is False:
+            if max_tokens == "auto":
+                # Calculate based on documents, ensuring it doesn't exceed base_model_max_tokens
+                percentile_90 = np.percentile([len(x.split(" ")) for x in documents], 90)
+                effective_max_tokens = min(
+                    math.floor((math.ceil((percentile_90 * 1.35) / 32) * 32) * 1.1),
+                    self.base_model_max_tokens,
+                )
+                effective_max_tokens = max(256, int(effective_max_tokens)) # Ensure a minimum reasonable length
+            else:
+                effective_max_tokens = min(int(max_tokens), self.base_model_max_tokens)
 
-            trainer.train(checkpoint=self.checkpoint)
-            return trainer.best_checkpoint_path()
+            if effective_max_tokens > 300 and self.verbose > 0 and max_tokens == "auto":
+                 print(
+                    f"Your documents are roughly {percentile_90} tokens long at the 90th percentile for this batch!",
+                    "This is quite long and might slow down reranking!\n",
+                    "Provide fewer documents, build smaller chunks or run on GPU if it takes too long for your needs!",
+                )
+
+            # Temporarily adjust the main inference_ckpt for this operation
+            # A more robust solution might involve creating a temporary tokenizer instance
+            self.inference_ckpt.colbert_config.doc_maxlen = effective_max_tokens
+            self.inference_ckpt.doc_tokenizer.doc_maxlen = effective_max_tokens
+            self._temp_inference_ckpt_len_set = True # Mark that we've set it for this call scope
+
+
+    def _reset_inference_max_tokens(self):
+        # Reset to base model's default after the operation
+        if hasattr(self, "_temp_inference_ckpt_len_set") and self._temp_inference_ckpt_len_set:
+            base_doc_maxlen = self.inference_ckpt.bert.config.max_position_embeddings - 4 # Re-calculate default
+            self.inference_ckpt.colbert_config.doc_maxlen = base_doc_maxlen
+            self.inference_ckpt.doc_tokenizer.doc_maxlen = base_doc_maxlen
+            del self._temp_inference_ckpt_len_set
+
 
     def _colbert_score(self, Q, D_padded, D_mask):
-        if ColBERTConfig().total_visible_gpus > 0:
+        # Standard ColBERT scoring logic
+        if ColBERTConfig().total_visible_gpus > 0: # Check global config for GPU availability
             Q, D_padded, D_mask = Q.cuda(), D_padded.cuda(), D_mask.cuda()
 
         assert Q.dim() == 3, Q.size()
@@ -465,108 +644,6 @@ class ColBERT(LateInteractionModel):
         scores = scores.max(1).values
         return scores.sum(-1)
 
-    def _index_free_search(
-        self,
-        embedded_queries,
-        documents: list[str],
-        embedded_docs,
-        doc_mask,
-        k: int = 10,
-        zero_index: bool = False,
-    ):
-        results = []
-
-        for query in embedded_queries:
-            results_for_query = []
-            scores = self._colbert_score(query, embedded_docs, doc_mask)
-            sorted_scores = torch.topk(scores, k)
-            for rank, doc_idx in enumerate(sorted_scores.indices.tolist()):
-                result = {
-                    "content": documents[doc_idx],
-                    "score": float(scores[doc_idx]),
-                    "rank": rank - 1 if zero_index else rank,
-                    "result_index": doc_idx,
-                }
-                results_for_query.append(result)
-            results.append(results_for_query)
-
-        if len(results) == 1:
-            return results[0]
-
-        return results
-
-    def _set_inference_max_tokens(
-        self, documents: list[str], max_tokens: Union[Literal["auto"], int] = "auto"
-    ):
-        if (
-            not hasattr(self, "inference_ckpt_len_set")
-            or self.inference_ckpt_len_set is False
-        ):
-            if max_tokens == "auto":
-                max_tokens = self.base_model_max_tokens
-            else:
-                max_tokens = int(max_tokens)
-            if max_tokens > self.base_model_max_tokens:
-                max_tokens = self.base_model_max_tokens
-                percentile_90 = np.percentile(
-                    [len(x.split(" ")) for x in documents], 90
-                )
-                max_tokens = min(
-                    math.floor((math.ceil((percentile_90 * 1.35) / 32) * 32) * 1.1),
-                    self.base_model_max_tokens,
-                )
-                max_tokens = max(256, max_tokens)
-
-                if max_tokens > 300:
-                    print(
-                        f"Your documents are roughly {percentile_90} tokens long at the 90th percentile!",
-                        "This is quite long and might slow down reranking!\n",
-                        "Provide fewer documents, build smaller chunks or run on GPU",
-                        "if it takes too long for your needs!",
-                    )
-            self.inference_ckpt.colbert_config.max_doclen = max_tokens
-            self.inference_ckpt.doc_tokenizer.doc_maxlen = max_tokens
-            self.inference_ckpt_len_set = True
-
-    def _index_free_retrieve(
-        self,
-        query: Union[str, list[str]],
-        documents: list[str],
-        k: int,
-        max_tokens: Union[Literal["auto"], int] = "auto",
-        zero_index: bool = False,
-        bsize: Union[Literal["auto"], int] = "auto",
-    ):
-        self._set_inference_max_tokens(documents=documents, max_tokens=max_tokens)
-
-        if k > len(documents):
-            print("k value cannot be larger than the number of documents! aborting...")
-            return None
-        if len(documents) > 1000:
-            print(
-                "Please note ranking in-memory is not optimised for large document counts! ",
-                "Consider building an index and using search instead!",
-            )
-        if len(set(documents)) != len(documents):
-            print(
-                "WARNING! Your documents have duplicate entries! ",
-                "This will slow down calculation and may yield subpar results",
-            )
-
-        embedded_queries = self._encode_index_free_queries(query, bsize=bsize)
-        embedded_docs, doc_mask = self._encode_index_free_documents(
-            documents, bsize=bsize
-        )
-
-        return self._index_free_search(
-            embedded_queries=embedded_queries,
-            documents=documents,
-            embedded_docs=embedded_docs,
-            doc_mask=doc_mask,
-            k=k,
-            zero_index=zero_index,
-        )
-
     def _encode_index_free_queries(
         self,
         queries: Union[str, list[str]],
@@ -576,172 +653,299 @@ class ColBERT(LateInteractionModel):
             bsize = 32
         if isinstance(queries, str):
             queries = [queries]
+
+        # Temporarily adjust query_maxlen for this batch of queries
+        original_query_maxlen = self.inference_ckpt.query_tokenizer.query_maxlen
         maxlen = max([int(len(x.split(" ")) * 1.35) for x in queries])
         self.inference_ckpt.query_tokenizer.query_maxlen = max(
-            min(maxlen, self.base_model_max_tokens), 32
+            min(maxlen, self.base_model_max_tokens), 32 # Maximize length but not over model capacity
         )
+
         embedded_queries = [
             x.unsqueeze(0)
-            for x in self.inference_ckpt.queryFromText(queries, bsize=bsize)
+            for x in self.inference_ckpt.queryFromText(queries, bsize=bsize, to_cpu=True) # Ensure CPU for general use
         ]
+
+        self.inference_ckpt.query_tokenizer.query_maxlen = original_query_maxlen # Restore
         return embedded_queries
 
     def _encode_index_free_documents(
         self,
         documents: list[str],
         bsize: Union[Literal["auto"], int] = "auto",
-        verbose: bool = True,
+        verbose_override: Optional[bool] = None,
     ):
+        effective_verbose = self.verbose > 0 if verbose_override is None else verbose_override
+
+        # bsize calculation needs to consider the currently set doc_maxlen on inference_ckpt
+        current_doc_maxlen_for_bsize_calc = self.inference_ckpt.doc_tokenizer.doc_maxlen
         if bsize == "auto":
             bsize = 32
-            if self.inference_ckpt.doc_tokenizer.doc_maxlen > 512:
-                bsize = max(
-                    1,
-                    int(
-                        32
-                        / (
-                            2
-                            ** round(
-                                math.log(
-                                    self.inference_ckpt.doc_tokenizer.doc_maxlen, 2
-                                )
-                            )
-                            / 512
-                        )
-                    ),
-                )
-                print("BSIZE:")
-                print(bsize)
-        embedded_docs = self.inference_ckpt.docFromText(
-            documents, bsize=bsize, showprogress=verbose
+            if current_doc_maxlen_for_bsize_calc > 512: # Example threshold
+                # Reduce bsize proportionally if doc_maxlen is very large to avoid OOM
+                factor = 2 ** round(math.log(current_doc_maxlen_for_bsize_calc / 512, 2))
+                bsize = max(1, int(32 / factor))
+                if effective_verbose:
+                    print(f"Auto bsize adjusted to {bsize} due to large doc_maxlen ({current_doc_maxlen_for_bsize_calc})")
+
+        # D_encoder returns (tensor, count). We only need tensor.
+        # to_cpu=True to ensure results are on CPU if not using GPU for ColBERT overall
+        embedded_docs_tensor = self.inference_ckpt.docFromText(
+            documents, bsize=bsize, showprogress=effective_verbose, to_cpu=True
         )[0]
-        doc_mask = torch.full(embedded_docs.shape[:2], -float("inf")).to(
-            embedded_docs.device
-        )
-        return embedded_docs, doc_mask
+
+        # Mask is usually for padding in ColBERT, here we create a full mask assuming all tokens are valid for scoring.
+        # This might need adjustment if specific masking strategies are required for index-free.
+        # For simple maxsim, the mask might not be strictly necessary if D_padded already handles lengths.
+        # However, _colbert_score expects D_mask.
+        doc_mask = torch.zeros(embedded_docs_tensor.shape[:2], device=embedded_docs_tensor.device) # All valid
+
+        return embedded_docs_tensor, doc_mask
+
+
+    def _index_free_search(
+        self,
+        embedded_queries, # List of query tensors
+        documents: list[str], # Original documents for retrieval
+        embedded_docs, # Tensor of document embeddings
+        doc_mask, # Document masks
+        k: int = 10,
+        zero_index_ranks: bool = False,
+    ):
+        results_all_queries = []
+
+        for query_tensor in embedded_queries: # query_tensor is [1, num_tokens, dim]
+            scores = self._colbert_score(query_tensor, embedded_docs, doc_mask) # scores will be [num_docs]
+
+            # Ensure k is not larger than number of documents
+            effective_k = min(k, embedded_docs.size(0))
+
+            top_k_scores, top_k_indices = torch.topk(scores, effective_k)
+
+            results_for_single_query = []
+            for rank, doc_idx_in_batch in enumerate(top_k_indices.tolist()):
+                result = {
+                    "content": documents[doc_idx_in_batch],
+                    "score": float(scores[doc_idx_in_batch]), # Get original score before topk for consistency
+                    "rank": rank if zero_index_ranks else rank + 1,
+                    "result_index": doc_idx_in_batch, # Index within the provided documents list
+                }
+                results_for_single_query.append(result)
+            results_all_queries.append(results_for_single_query)
+
+        return results_all_queries[0] if len(results_all_queries) == 1 else results_all_queries
+
 
     def rank(
         self,
-        query: str,
+        query: str, # Single query string for ranking
         documents: list[str],
         k: int = 10,
         zero_index_ranks: bool = False,
-        bsize: int = 32,
+        bsize: Union[Literal["auto"], int] = "auto",
+        max_tokens: Union[Literal["auto"], int] = "auto",
     ):
-        self._set_inference_max_tokens(documents=documents, max_tokens="auto")
-        self.inference_ckpt_len_set = False
-        return self._index_free_retrieve(
-            query, documents, k, zero_index=zero_index_ranks, bsize=bsize
-        )
+        if not documents:
+            return []
+        if k > len(documents):
+            if self.verbose > 0:
+                print(f"Warning: k value ({k}) for rank is larger than the number of documents ({len(documents)}). Adjusting k.")
+            k = len(documents)
 
+        try:
+            self._set_inference_max_tokens(documents=documents, max_tokens=max_tokens)
+
+            # Encode query
+            embedded_queries = self._encode_index_free_queries([query], bsize=bsize) # List with one query tensor
+
+            # Encode documents
+            # verbose_override=False for document encoding within rank unless self.verbose is high
+            embedded_docs, doc_mask = self._encode_index_free_documents(documents, bsize=bsize, verbose_override=(self.verbose > 1))
+
+            # Perform search (ranking)
+            # _index_free_search returns list of lists; since it's one query, take first element
+            ranked_results = self._index_free_search(
+                embedded_queries, documents, embedded_docs, doc_mask, k, zero_index_ranks
+            )
+            return ranked_results # This will be the list of dicts for the single query
+        finally:
+            self._reset_inference_max_tokens()
+
+
+    # --- Methods for managing cached encoded documents (experimental) ---
+    # These would allow encoding a large set once and searching over it multiple times.
     def encode(
         self,
         documents: list[str],
-        document_metadatas: Optional[list[dict]] = None,
+        document_metadatas: Optional[List[Optional[Dict[str, Any]]]] = None, # Optional metadata per document
         bsize: int = 32,
         max_tokens: Union[Literal["auto"], int] = "auto",
-        verbose: bool = True,
+        verbose_override: Optional[bool] = None,
     ):
-        self._set_inference_max_tokens(documents=documents, max_tokens=max_tokens)
-        encodings, doc_masks = self._encode_index_free_documents(
-            documents, bsize=bsize, verbose=verbose
-        )
-        encodings = torch.cat(
-            [
-                encodings,
-                torch.zeros(
-                    (
-                        encodings.shape[0],
-                        self.inference_ckpt.doc_tokenizer.doc_maxlen
-                        - encodings.shape[1],
-                        encodings.shape[2],
-                    )
-                ).to(device=encodings.device),
-            ],
-            dim=1,
-        )
-        doc_masks = torch.cat(
-            [
-                doc_masks,
-                torch.full(
-                    (
-                        doc_masks.shape[0],
-                        self.inference_ckpt.colbert_config.max_doclen
-                        - doc_masks.shape[1],
-                    ),
-                    -float("inf"),
-                ).to(device=doc_masks.device),
-            ],
-            dim=1,
-        )
+        """Encodes documents and stores them in memory for subsequent `search_encoded_docs` calls."""
+        if not hasattr(self, "_cached_encodings"):
+            self._cached_encodings = {
+                "collection": [],
+                "metadatas": [],
+                "embeddings": None, # Will be a tensor
+                "masks": None, # Will be a tensor
+                "doc_maxlen_at_encoding": 0,
+            }
 
-        if verbose:
-            print("Shapes:")
-            print(f"encodings: {encodings.shape}")
-            print(f"doc_masks: {doc_masks.shape}")
+        effective_verbose = self.verbose > 0 if verbose_override is None else verbose_override
+        try:
+            self._set_inference_max_tokens(documents=documents, max_tokens=max_tokens)
 
-        if hasattr(self, "in_memory_collection"):
-            if self.in_memory_metadata is not None:
-                if document_metadatas is None:
-                    self.in_memory_metadatas.extend([None] * len(documents))
-                else:
-                    self.in_memory_metadata.extend(document_metadatas)
-            elif document_metadatas is not None:
-                self.in_memory_metadata = [None] * len(self.in_memory_collection)
-                self.in_memory_metadata.extend(document_metadatas)
+            # Store the doc_maxlen used for this batch, important if concatenating
+            current_encoding_doc_maxlen = self.inference_ckpt.doc_tokenizer.doc_maxlen
 
-            self.in_memory_collection.extend(documents)
-
-            # add 0 padding to encodings so they're self.inference_ckpt.doc_tokenizer.doc_maxlen length
-
-            self.in_memory_embed_docs = torch.cat(
-                [self.in_memory_embed_docs, encodings], dim=0
+            new_embeddings, new_masks = self._encode_index_free_documents(
+                documents, bsize=bsize, verbose_override=effective_verbose
             )
-            self.doc_masks = torch.cat([self.doc_masks, doc_masks], dim=0)
 
-        else:
-            self.in_memory_collection = documents
-            self.in_memory_metadata = document_metadatas
-            self.in_memory_embed_docs = encodings
-            self.doc_masks = doc_masks
+            # Normalize embedding shapes for concatenation if doc_maxlen changed
+            if self._cached_encodings["embeddings"] is not None:
+                # If cached encodings exist, all new encodings must match its doc_maxlen
+                # Or, more robustly, pad all to the largest encountered doc_maxlen
+                # For now, let's assume subsequent encodes try to match or clear first
+                if current_encoding_doc_maxlen != self._cached_encodings["doc_maxlen_at_encoding"]:
+                    # This logic needs to be robust: pad existing or new to match a common dimension.
+                    # Simplest for now: raise error or warn, require consistent max_tokens or clear cache.
+                    print(f"Warning: max_tokens for this encode call ({current_encoding_doc_maxlen}) differs from cached ({self._cached_encodings['doc_maxlen_at_encoding']}). Results may be inconsistent if concatenating. Consider clearing cache or using consistent max_tokens.")
+                    # Fallback: Pad new_embeddings to match cached dimension if smaller, or re-encode all if larger (costly)
+                    # This padding ensures self._colbert_score doesn't fail on shape mismatch.
+                    if new_embeddings.shape[1] < self._cached_encodings["doc_maxlen_at_encoding"]:
+                        padding_size = self._cached_encodings["doc_maxlen_at_encoding"] - new_embeddings.shape[1]
+                        pad_tensor = torch.zeros(new_embeddings.shape[0], padding_size, new_embeddings.shape[2], device=new_embeddings.device)
+                        new_embeddings = torch.cat([new_embeddings, pad_tensor], dim=1)
+                        # Also pad masks if they are length-dependent (current D_mask from _encode_index_free is not, but good practice)
+
+            self._cached_encodings["collection"].extend(documents)
+            if document_metadatas:
+                self._cached_encodings["metadatas"].extend(document_metadatas)
+            else:
+                self._cached_encodings["metadatas"].extend([None] * len(documents))
+
+            if self._cached_encodings["embeddings"] is None:
+                self._cached_encodings["embeddings"] = new_embeddings
+                self._cached_encodings["masks"] = new_masks
+                self._cached_encodings["doc_maxlen_at_encoding"] = current_encoding_doc_maxlen
+            else:
+                # Ensure device consistency before cat
+                device = self._cached_encodings["embeddings"].device
+                self._cached_encodings["embeddings"] = torch.cat(
+                    [self._cached_encodings["embeddings"], new_embeddings.to(device)], dim=0
+                )
+                self._cached_encodings["masks"] = torch.cat(
+                    [self._cached_encodings["masks"], new_masks.to(device)], dim=0
+                )
+            if effective_verbose:
+                print(f"Encoded {len(documents)} documents. Total cached: {len(self._cached_encodings['collection'])}.")
+
+        finally:
+            self._reset_inference_max_tokens()
+
 
     def search_encoded_docs(
         self,
         queries: Union[str, list[str]],
         k: int = 10,
-        bsize: int = 32,
+        bsize: int = 32, # For query encoding
+        zero_index_ranks: bool = False,
     ):
-        queries = self._encode_index_free_queries(queries, bsize=bsize)
+        if not hasattr(self, "_cached_encodings") or self._cached_encodings["embeddings"] is None:
+            print("No documents have been encoded and cached. Call .encode() first.")
+            return [] if isinstance(queries, str) else [[] for _ in queries]
+
+        # Encode queries (max_tokens for queries is handled by _encode_index_free_queries)
+        embedded_queries = self._encode_index_free_queries(queries, bsize=bsize)
+
         results = self._index_free_search(
-            embedded_queries=queries,
-            documents=self.in_memory_collection,
-            embedded_docs=self.in_memory_embed_docs,
-            doc_mask=self.doc_masks,
-            k=k,
+            embedded_queries,
+            self._cached_encodings["collection"],
+            self._cached_encodings["embeddings"],
+            self._cached_encodings["masks"],
+            k,
+            zero_index_ranks,
         )
-        if self.in_memory_metadata is not None:
-            for result in results:
-                result["document_metadata"] = self.in_memory_metadata[
-                    result["result_index"]
-                ]
-        return results
+
+        # Add metadata if available
+        # results is either a list of dicts (single query) or list of lists of dicts (multi-query)
+        def add_meta(single_query_results_list):
+            for r_dict in single_query_results_list:
+                doc_meta = self._cached_encodings["metadatas"][r_dict["result_index"]]
+                if doc_meta:
+                    r_dict["document_metadata"] = doc_meta
+            return single_query_results_list
+
+        if isinstance(queries, str): # Single query, results is a list of dicts
+            return add_meta(results)
+        else: # Multiple queries, results is a list of lists of dicts
+            return [add_meta(res_list) for res_list in results]
+
 
     def clear_encoded_docs(self, force: bool = False):
+        if not hasattr(self, "_cached_encodings") or self._cached_encodings["embeddings"] is None:
+            print("No cached encodings to clear.")
+            return
+
         if not force:
-            print(
-                "All in-memory encodings will be deleted in 10 seconds, interrupt now if you want to keep them!"
-            )
-            print("...")
-            time.sleep(10)
-        del self.in_memory_collection
-        del self.in_memory_metadata
-        del self.in_memory_embed_docs
-        del self.doc_masks
-        del self.inference_ckpt_len_set
+            if self.verbose > 0:
+                print("All in-memory encodings will be deleted in 5 seconds. Interrupt to cancel.")
+            time.sleep(5)
+
+        self._cached_encodings = {
+            "collection": [], "metadatas": [], "embeddings": None, "masks": None, "doc_maxlen_at_encoding":0
+        }
+        if torch.cuda.is_available(): # Try to free GPU memory if used
+            torch.cuda.empty_cache()
+        if self.verbose > 0:
+            print("Cached encoded documents cleared.")
+
+
+    # --- Training method (largely unchanged, uses global RunContext) ---
+    def train(self, index_name_for_config: Optional[str], data_dir: Union[str, Path], training_config_overrides: Dict[str, Any]) -> str:
+        # Training often creates a new model/checkpoint.
+        # It needs a ColBERTConfig. If an index_name is provided, use its config as a base.
+        # Otherwise, use the base_model_config.
+        if index_name_for_config:
+            base_train_config = self._get_or_load_index_context(index_name_for_config, create_if_not_exists=False) # Should exist
+        else:
+            base_train_config = self.base_model_config # Default if no specific index config
+
+        # Construct ColBERTConfig from the dictionary of overrides
+        override_config_obj = ColBERTConfig(**training_config_overrides)
+        final_training_config = ColBERTConfig.from_existing(base_train_config, override_config_obj)
+        final_training_config.nway = 2 # Common setting for ColBERT training
+
+        data_path = Path(data_dir)
+
+        # Run().context(self.run_config) is already active globally for the class instance
+        trainer = Trainer(
+            triples=str(data_path / "triples.train.colbert.jsonl"),
+            queries=str(data_path / "queries.train.colbert.tsv"),
+            collection=str(data_path / "corpus.train.colbert.tsv"),
+            config=final_training_config, # Pass the resolved training config
+        )
+        # Trainer uses the checkpoint from the ColBERTConfig if not specified otherwise
+        trainer.train(checkpoint=str(self.base_pretrained_model_name_or_path))
+
+        if self.verbose > 0:
+            print(f"Training complete. Best checkpoint saved to: {trainer.path_}") # trainer.path_ is new standard
+        return trainer.path_
+
 
     def __del__(self):
-        # Clean up context
+        # Clean up global ColBERT context
         try:
-            self.run_context.__exit__(None, None, None)
+            if hasattr(self, 'run_context') and self.run_context:
+                self.run_context.__exit__(None, None, None)
         except Exception:
-            print("INFO: Tried to clean up context but failed!")
+            if self.verbose > 0: # Only print if verbose
+                print("INFO: Tried to clean up ColBERT RunContext but failed. This is usually not critical.")
+
+        # Clear cached encodings if any, to free memory
+        if hasattr(self, "_cached_encodings"):
+            del self._cached_encodings
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()

--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -340,7 +340,13 @@ class ColBERT(LateInteractionModel):
 
         current_collection = self.collections.get(index_name, [])
         current_pid_docid_map = self.pid_docid_maps.get(index_name, {})
-        current_docid_metadata_map = self.docid_metadata_maps.get(index_name, defaultdict(lambda: None))
+        # Ensure current_docid_metadata_map is a dict, not None, before .update()
+        current_docid_metadata_map_val = self.docid_metadata_maps.get(index_name)
+        if current_docid_metadata_map_val is None:
+            current_docid_metadata_map = {}
+        else:
+            current_docid_metadata_map = current_docid_metadata_map_val
+
 
         # Filter out documents whose document_ids are already present
         # This assumes new_pid_docid_map_for_new_docs gives the final intended document_id for each new passage
@@ -372,8 +378,9 @@ class ColBERT(LateInteractionModel):
         current_collection.extend(new_collection_for_indexer)
 
         if new_docid_metadata_map:
+            # current_docid_metadata_map is guaranteed to be a dict here
             current_docid_metadata_map.update(new_docid_metadata_map)
-
+        
         self.collections[index_name] = current_collection
         self.pid_docid_maps[index_name] = current_pid_docid_map
         self.docid_metadata_maps[index_name] = current_docid_metadata_map

--- a/ragatouille/server/server.py
+++ b/ragatouille/server/server.py
@@ -2,7 +2,7 @@ import argparse
 from typing import List, Dict, Optional
 import os
 
-import batched
+# import batched # Batched processing is currently commented out
 import uvicorn
 from fastapi import FastAPI, HTTPException, APIRouter
 from pydantic import BaseModel
@@ -13,20 +13,20 @@ from ragatouille import RAGPretrainedModel
 app = FastAPI()
 
 class DocumentMetadata(BaseModel):
-    id: str
-    project_id: str
+    id: str # Unique ID for the original document
+    project_id: str # Example metadata field
 
 class IndexRequest(BaseModel):
-    """PyDantic model for the requests sent to the server.
+    """PyDantic model for the requests sent to the /index endpoint.
 
     Parameters
     ----------
     input
-        The input(s) to encode.
+        A list of document texts to be indexed.
     metadata
-        The metadata of the quotes.
+        A list of metadata objects, one for each document in `input`.
     index_id
-        The id of the index.
+        The identifier for the index to be created or updated.
     """
 
     input: List[str]
@@ -35,14 +35,16 @@ class IndexRequest(BaseModel):
 
 
 class QueryRequest(BaseModel):
-    """PyDantic model for the requests sent to the server.
+    """PyDantic model for the requests sent to the /query endpoint.
 
     Parameters
     ----------
     input
-        The input(s) to encode.
+        A list of query strings.
     index_id
-        The id of the index
+        The identifier of the index to query.
+    k
+        Optional number of results to return per query.
     """
 
     input: List[str]
@@ -51,49 +53,65 @@ class QueryRequest(BaseModel):
 
 
 class QueryResponse(BaseModel):
-    """PyDantic model for the server answer to a call.
+    """PyDantic model for the server answer to a /query call.
 
     Parameters
     ----------
     data
-        pass
+        List of search results. For multiple input queries, this will be a list of lists.
     model
-        The name of the model used for encoding.
+        The name of the base model used for encoding.
     """
 
-    data: List[List[Dict]]
+    data: List[List[Dict]] # Assuming search always returns a list of lists for multiple queries
     model: str
 
 
-def wrap_encode_function(model, **kwargs):
-    def wrapped_encode(sentences):
-        return model.encode(sentences, **kwargs)
-
-    return wrapped_encode
+# Batched processing currently not used with the single model refactor
+# def wrap_encode_function(model, **kwargs):
+#     def wrapped_encode(sentences):
+#         return model.encode(sentences, **kwargs)
+#     return wrapped_encode
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Run FastAPI ColBERT serving server with specified host, port, and model."
-    )
-    parser.add_argument(
-        "--index_name",
-        type=str,
-        help="Index name to load",
-    )
-    parser.add_argument(
-        "--host", type=str, default="0.0.0.0", help="Host to run the server on"
-    )
-    parser.add_argument(
-        "--port", type=int, default=8002, help="Port to run the server on"
+        description="Run FastAPI RAGatouille server with specified host, port, base model, and index root."
     )
     parser.add_argument(
         "--model",
         type=str,
         default="jinaai/jina-colbert-v2",
-        help="Model to serve, can be an HF model or a path to a model",
+        help="Base model to serve, can be an HF model name or a path to a local ColBERT checkpoint.",
     )
-    parser.add_argument("--reload", action="store_true", help="Enable hot reload")
+    parser.add_argument(
+        "--index-root",
+        dest="index_root",
+        type=str,
+        default="./ragatouille/colbert/indexes", # Default root directory for all indices
+        help="Root directory where all named indices will be stored and loaded from.",
+    )
+    parser.add_argument(
+        "--host", type=str, default="0.0.0.0", help="Host to run the server on."
+    )
+    parser.add_argument(
+        "--port", type=int, default=8002, help="Port to run the server on."
+    )
+    parser.add_argument(
+        "--experiment-name",
+        dest="experiment_name",
+        type=str,
+        default="colbert",
+        help="Experiment name used in structuring index paths under index_root.",
+    )
+    parser.add_argument(
+        "--initial-index-name",
+        dest="initial_index_name",
+        type=str,
+        default=None,
+        help="Optional: Name of an index within index_root to pre-load at startup."
+    )
+    parser.add_argument("--reload", action="store_true", help="Enable hot reload for development.")
 
     return parser.parse_args()
 
@@ -102,69 +120,146 @@ args = parse_args()
 
 if args.reload:
     os.environ["API_RELOAD"] = "true"
-    print("API_RELOAD enabled by --reload")
+    print("API_RELOAD enabled by --reload flag.")
 
-# We need to load the model here so it is shared for every request
-model = RAGPretrainedModel.from_index(args.index_name)
-# We cannot create the function on the fly as the batching require to use the same function (memory address)
-# TODO still can't do this, especially if we will be separating indices by project_id.
-#model.search = batched.aio.dynamically(
-#    wrap_encode_function(model, is_query=True)
-#)
-#model.encode_document = batched.aio.dynamically(
-#    wrap_encode_function(model, is_query=False)
-#)
+# Load the single RAGPretrainedModel instance
+# This model instance will manage multiple indices under args.index_root
+try:
+    print(f"Loading RAGPretrainedModel with base model: {args.model}")
+    print(f"Index root set to: {args.index_root}")
+    if args.initial_index_name:
+        print(f"Attempting to pre-load initial index: {args.initial_index_name}")
+
+    model = RAGPretrainedModel.from_pretrained(
+        pretrained_model_name_or_path=args.model,
+        index_root=args.index_root,
+        initial_index_name=args.initial_index_name,
+        experiment_name=args.experiment_name,
+        # Add other RAGPretrainedModel.from_pretrained parameters if needed (e.g., n_gpu, verbose)
+    )
+    print("RAGPretrainedModel loaded successfully.")
+except Exception as e:
+    print(f"Error loading RAGPretrainedModel: {e}")
+    # Depending on server resilience requirements, you might exit or try to run degraded
+    raise RuntimeError(f"Failed to initialize RAGPretrainedModel: {e}") from e
+
 
 router = APIRouter()
 
-@router.post("/index")
-async def index(request: IndexRequest):
-    """API endpoint that encode the elements of an EmbeddingRequest and returns an EmbeddingResponse.
-
-    Parameters
-    ----------
-    request
-        The IndexRequest
+@router.post("/index/create")
+async def create_index(request: IndexRequest):
+    """
+    API endpoint to index a list of documents.
+    If the index_id does not exist, a new index will be created.
+    If it exists, behavior depends on the underlying ColBERT index overwrite policy (default "reuse").
     """
     try:
+        if not request.input:
+            raise HTTPException(status_code=400, detail="Input documents list cannot be empty.")
+        if len(request.input) != len(request.metadata):
+            raise HTTPException(status_code=400, detail="Length of input documents and metadata must match.")
+
+        document_ids = [meta.id for meta in request.metadata]
+        # Ensure document_ids are unique as RAGPretrainedModel expects this
+        if len(document_ids) != len(set(document_ids)):
+            raise HTTPException(status_code=400, detail="Document IDs in metadata must be unique.")
+
+        document_metadatas = [{"project_id": meta.project_id} for meta in request.metadata]
+
+        print(f"Indexing documents for index_id: {request.index_id}...")
+        # RAGPretrainedModel.index will handle splitting and creating ColBERT index
+        # Overwrite policy is handled by ColBERT (default "reuse")
+        index_path = model.index(
+            index_name=request.index_id,
+            documents=request.input,
+            document_ids=document_ids,
+            document_metadatas=document_metadatas,
+            # max_document_length, bsize, use_faiss_index can be exposed or configured as needed
+        )
+        print(f"Documents indexed for index_id: {request.index_id}. Index path: {index_path}")
+        return JSONResponse(status_code=201, content={"result": "ok", "index_path": index_path})
+    except ValueError as ve: # Catch specific errors like ID mismatches from RAGatouille
+        raise HTTPException(status_code=400, detail=str(ve))
+    except Exception as e:
+        print(f"Error during indexing for index_id {request.index_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/index/add")
+async def add_to_index(request: IndexRequest):
+    """
+    API endpoint to index a list of documents.
+    If the index_id does not exist, a new index will be created.
+    If it exists, behavior depends on the underlying ColBERT index overwrite policy (default "reuse").
+    """
+    try:
+        if not request.input:
+            raise HTTPException(status_code=400, detail="Input documents list cannot be empty.")
+        if len(request.input) != len(request.metadata):
+            raise HTTPException(status_code=400, detail="Length of input documents and metadata must match.")
+
+        document_ids = [meta.id for meta in request.metadata]
+        # Ensure document_ids are unique as RAGPretrainedModel expects this
+        if len(document_ids) != len(set(document_ids)):
+            raise HTTPException(status_code=400, detail="Document IDs in metadata must be unique.")
+
+        document_metadatas = [{"project_id": meta.project_id} for meta in request.metadata]
+
+        print(f"Indexing documents for index_id: {request.index_id}...")
         model.add_to_index(
-            request.input
+            index_name=request.index_id,
+            new_documents=request.input,
+            new_document_ids=document_ids,
+            new_document_metadatas=document_metadatas,
         )
         return JSONResponse(status_code=201, content={"result": "ok"})
+    except ValueError as ve: # Catch specific errors like ID mismatches from RAGatouille
+        raise HTTPException(status_code=400, detail=str(ve))
     except Exception as e:
+        print(f"Error during indexing for index_id {request.index_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post("/query", response_model=QueryResponse)
-async def query(request: QueryRequest):
-    """API endpoint that encode the elements of an EmbeddingRequest and returns an EmbeddingResponse.
-
-    Parameters
-    ----------
-    request
-        The QueryRequest
+async def query_index(request: QueryRequest):
+    """
+    API endpoint to query an index.
     """
     try:
-        if request.k is None:
-            k = 5
-        else:
-            k = request.k
+        if not request.input:
+            raise HTTPException(status_code=400, detail="Input query list cannot be empty.")
 
-        docs = model.search(request.input, k=k)
-        if len(request.input) == 1:
-            print("Only 1 query, wrapping...")
-            docs = [docs]
+        k_val = request.k if request.k is not None else 5 # Default k if not provided
 
-        return QueryResponse(
-            model="jinaai/jina-colbert-v2",
-            data=docs
+        print(f"Querying index_id: {request.index_id} with k={k_val}...")
+        # RAGPretrainedModel.search handles loading the correct index context
+        search_results = model.search(
+            index_name=request.index_id,
+            query=request.input,
+            k=k_val
         )
+
+        # Ensure results are always a list of lists, even for a single query
+        if len(request.input) == 1 and not isinstance(search_results[0], list):
+            final_results = [search_results]
+        else:
+            final_results = search_results
+
+        print(f"Query successful for index_id: {request.index_id}.")
+        return QueryResponse(
+            model=model.get_model().base_pretrained_model_name_or_path, # Get base model name
+            data=final_results
+        )
+    except FileNotFoundError as fnfe: # Specific error if index doesn't exist for querying
+        print(f"Index not found for query: {request.index_id}. Error: {fnfe}")
+        raise HTTPException(status_code=404, detail=f"Index '{request.index_id}' not found.")
     except Exception as e:
+        print(f"Error during query for index_id {request.index_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 app.include_router(router, prefix="/api/v1")
 
 if __name__ == "__main__":
-    reload = os.getenv("API_RELOAD", "false").lower() == "true"
-    module_path = "ragatouille.server.server:app"
-    uvicorn.run(module_path, host=args.host, port=args.port, reload=reload)
+    is_reload = os.getenv("API_RELOAD", "false").lower() == "true"
+    module_path = "ragatouille.server.server:app" # Standard for uvicorn
+    uvicorn.run(module_path, host=args.host, port=args.port, reload=is_reload)

--- a/tests/e2e/test_e2e_indexing_searching.py
+++ b/tests/e2e/test_e2e_indexing_searching.py
@@ -1,91 +1,118 @@
 import pytest
 import srsly
+import os
+from pathlib import Path
 
 from ragatouille import RAGPretrainedModel
 from ragatouille.utils import get_wikipedia_page
 
+# Define a common index root for the test session using pytest's tmp_path_factory
+@pytest.fixture(scope="session")
+def session_index_root(tmp_path_factory):
+    return tmp_path_factory.mktemp("ragatouille_e2e_tests_root")
 
-def test_indexing():
-    RAG = RAGPretrainedModel.from_pretrained("colbert-ir/colbertv2.0")
+@pytest.fixture(scope="session")
+def model_name():
+    return "colbert-ir/colbertv2.0" # Or a smaller test model if available
+
+@pytest.fixture(scope="session")
+def experiment_name():
+    return "colbert" # Keep test experiments separate
+
+@pytest.fixture(scope="session")
+def miyazaki_index_name():
+    return "Miyazaki"
+
+@pytest.fixture(scope="session")
+def miyazaki_index_path(session_index_root, experiment_name, miyazaki_index_name):
+    return Path(session_index_root) / experiment_name / "indexes" / miyazaki_index_name
+
+@pytest.fixture(scope="session")
+def rag_model_for_indexing(model_name, session_index_root, experiment_name):
+    """RAG model instance for indexing tests."""
+    return RAGPretrainedModel.from_pretrained(
+        model_name,
+        index_root=str(session_index_root),
+        experiment_name=experiment_name
+    )
+
+def test_indexing(rag_model_for_indexing, miyazaki_index_name, miyazaki_index_path):
+    RAG = rag_model_for_indexing
     with open("tests/data/miyazaki_wikipedia.txt", "r") as f:
         full_document = f.read()
+
+    # RAG.index now takes 'documents' and 'document_ids'
+    # 'split_documents' is handled by the CorpusProcessor inside RAGPretrainedModel
+    # 'max_document_length' is used as chunk_size for the default splitter
     RAG.index(
-        collection=[full_document],
-        index_name="Miyazaki",
+        index_name=miyazaki_index_name,
+        documents=[full_document],
+        document_ids=["miyazaki_doc_1"], # Must provide document_ids
         max_document_length=180,
-        split_documents=True,
     )
     # ensure collection is stored to disk
-    collection = srsly.read_json(
-        ".ragatouille/colbert/indexes/Miyazaki/collection.json"
+    collection_path = miyazaki_index_path / "collection.json"
+    assert collection_path.exists(), f"Collection file not found at {collection_path}"
+    collection = srsly.read_json(str(collection_path))
+    assert len(collection) > 1, "Collection should have more than one chunk"
+
+
+def test_search(model_name, miyazaki_index_name, miyazaki_index_path):
+    # Ensure the index exists from test_indexing
+    assert miyazaki_index_path.exists(), f"Index path {miyazaki_index_path} must exist from a previous indexing step."
+
+    # from_index now also requires pretrained_model_name_or_path
+    RAG = RAGPretrainedModel.from_index(
+        index_path=str(miyazaki_index_path),
+        pretrained_model_name_or_path=model_name
     )
-    assert len(collection) > 1
-
-
-def test_search():
-    RAG = RAGPretrainedModel.from_index(".ragatouille/colbert/indexes/Miyazaki/")
-    k = 3  # How many documents you want to retrieve, defaults to 10, we set it to 3 here for readability
-    results = RAG.search(query="What animation studio did Miyazaki found?", k=k)
+    k = 3
+    # search now requires index_name
+    results = RAG.search(index_name=miyazaki_index_name, query="What animation studio did Miyazaki found?", k=k)
     assert len(results) == k
-    assert (
-        "In April 1984, Miyazaki opened his own office in Suginami Ward"
-        in results[0]["content"]
-    )
-    assert (
-        "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941)"  # noqa
-        in results[1]["content"]
-    )
-    assert (
-        'Glen Keane said Miyazaki is a "huge influence" on Walt Disney Animation Studios and has been'  # noqa
-        in results[2]["content"]
-    )
+    # Content assertions can be brittle, checking for presence is okay
+    assert "Studio Ghibli" in results[0]["content"] or "Nibariki" in results[0]["content"]
 
     all_results = RAG.search(
+        index_name=miyazaki_index_name,
         query=["What animation studio did Miyazaki found?", "Miyazaki son name"], k=k
     )
-    assert (
-        "In April 1984, Miyazaki opened his own office in Suginami Ward"
-        in all_results[0][0]["content"]
-    )
-    assert (
-        "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941)"  # noqa
-        in all_results[0][1]["content"]
-    )
-    assert (
-        'Glen Keane said Miyazaki is a "huge influence" on Walt Disney Animation Studios and has been'  # noqa
-        in all_results[0][2]["content"]
-    )
-    assert (
-        "== Early life ==\nHayao Miyazaki was born on January 5, 1941"
-        in all_results[1][0]["content"]  # noqa
-    )
-    assert (
-        "Directed by Isao Takahata, with whom Miyazaki would continue to collaborate for the remainder of his career"  # noqa
-        in all_results[1][1]["content"]
-    )
-    actual = all_results[1][2]["content"]
-    assert (
-        "Specific works that have influenced Miyazaki include Animal Farm (1945)"
-        in actual
-        or "She met with Suzuki" in actual
-    )
+    assert len(all_results) == 2
+    assert len(all_results[0]) == k
+    assert len(all_results[1]) == k
+    assert "Studio Ghibli" in all_results[0][0]["content"] or "Nibariki" in all_results[0][0]["content"]
+    assert "Goro" in all_results[1][0]["content"] or "Keisuke" in all_results[1][0]["content"]
     print(all_results)
 
 
-@pytest.mark.skip(reason="experimental feature.")
-def test_basic_CRUD_addition():
-    old_collection = srsly.read_json(
-        ".ragatouille/colbert/indexes/Miyazaki/collection.json"
-    )
+@pytest.mark.skip(reason="experimental feature, needs careful review of add_to_index impact on existing data.")
+def test_basic_CRUD_addition(model_name, miyazaki_index_name, miyazaki_index_path):
+    assert miyazaki_index_path.exists(), f"Index path {miyazaki_index_path} must exist from a previous indexing step."
+    collection_path = miyazaki_index_path / "collection.json"
+
+    old_collection = srsly.read_json(str(collection_path))
     old_collection_len = len(old_collection)
-    path_to_index = ".ragatouille/colbert/indexes/Miyazaki/"
-    RAG = RAGPretrainedModel.from_index(path_to_index)
 
-    new_documents = get_wikipedia_page("Studio_Ghibli")
-
-    RAG.add_to_index([new_documents])
-    new_collection = srsly.read_json(
-        ".ragatouille/colbert/indexes/Miyazaki/collection.json"
+    RAG = RAGPretrainedModel.from_index(
+        index_path=str(miyazaki_index_path),
+        pretrained_model_name_or_path=model_name
     )
+
+    new_document_text = get_wikipedia_page("Studio_Ghibli") # Assuming this returns a single string
+
+    # add_to_index requires index_name, new_documents (list of strings), and new_document_ids (list of strings)
+    RAG.add_to_index(
+        index_name=miyazaki_index_name,
+        new_documents=[new_document_text],
+        new_document_ids=["studio_ghibli_doc_CRUD"] # Provide a unique ID for the new document
+    )
+
+    new_collection = srsly.read_json(str(collection_path))
     assert len(new_collection) > old_collection_len
-    assert len(new_collection) == 140
+    # The exact number of chunks (like 140) can be very specific and brittle.
+    # It's better to assert that the collection grew and that content from the new doc is searchable.
+
+    # Optional: Verify new content is searchable
+    results = RAG.search(index_name=miyazaki_index_name, query="Tokuma Shoten", k=1)
+    assert len(results) > 0
+    assert "Tokuma Shoten" in results[0]["content"]

--- a/tests/e2e/test_e2e_indexing_searching.py
+++ b/tests/e2e/test_e2e_indexing_searching.py
@@ -49,6 +49,7 @@ def test_indexing(rag_model_for_indexing, miyazaki_index_name, miyazaki_index_pa
         documents=[full_document],
         document_ids=["miyazaki_doc_1"], # Must provide document_ids
         max_document_length=180,
+        split_documents=True
     )
     # ensure collection is stored to disk
     collection_path = miyazaki_index_path / "collection.json"
@@ -70,18 +71,50 @@ def test_search(model_name, miyazaki_index_name, miyazaki_index_path):
     # search now requires index_name
     results = RAG.search(index_name=miyazaki_index_name, query="What animation studio did Miyazaki found?", k=k)
     assert len(results) == k
-    # Content assertions can be brittle, checking for presence is okay
-    assert "Studio Ghibli" in results[0]["content"] or "Nibariki" in results[0]["content"]
+    assert (
+        "In April 1984, Miyazaki opened his own office in Suginami Ward"
+        in results[0]["content"]
+    )
+    assert (
+        "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941)"  # noqa
+        in results[1]["content"]
+    )
+    assert (
+        'Glen Keane said Miyazaki is a "huge influence" on Walt Disney Animation Studios and has been'  # noqa
+        in results[2]["content"]
+    )
 
     all_results = RAG.search(
         index_name=miyazaki_index_name,
-        query=["What animation studio did Miyazaki found?", "Miyazaki son name"], k=k
+        query=["What animation studio did Miyazaki found?", "Miyazaki son name"],
+        k=k
     )
-    assert len(all_results) == 2
-    assert len(all_results[0]) == k
-    assert len(all_results[1]) == k
-    assert "Studio Ghibli" in all_results[0][0]["content"] or "Nibariki" in all_results[0][0]["content"]
-    assert "Goro" in all_results[1][0]["content"] or "Keisuke" in all_results[1][0]["content"]
+    assert (
+        "In April 1984, Miyazaki opened his own office in Suginami Ward"
+        in all_results[0][0]["content"]
+    )
+    assert (
+        "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941)"  # noqa
+        in all_results[0][1]["content"]
+    )
+    assert (
+        'Glen Keane said Miyazaki is a "huge influence" on Walt Disney Animation Studios and has been'  # noqa
+        in all_results[0][2]["content"]
+    )
+    assert (
+        "== Early life ==\nHayao Miyazaki was born on January 5, 1941"
+        in all_results[1][0]["content"]  # noqa
+    )
+    assert (
+        "Directed by Isao Takahata, with whom Miyazaki would continue to collaborate for the remainder of his career"  # noqa
+        in all_results[1][1]["content"]
+    )
+    actual = all_results[1][2]["content"]
+    assert (
+        "Specific works that have influenced Miyazaki include Animal Farm (1945)"
+        in actual
+        or "She met with Suzuki" in actual
+    )
     print(all_results)
 
 
@@ -98,20 +131,16 @@ def test_basic_CRUD_addition(model_name, miyazaki_index_name, miyazaki_index_pat
         pretrained_model_name_or_path=model_name
     )
 
-    new_document_text = get_wikipedia_page("Studio_Ghibli") # Assuming this returns a single string
+    new_document_text = get_wikipedia_page("Studio_Ghibli")
 
-    # add_to_index requires index_name, new_documents (list of strings), and new_document_ids (list of strings)
     RAG.add_to_index(
         index_name=miyazaki_index_name,
         new_documents=[new_document_text],
-        new_document_ids=["studio_ghibli_doc_CRUD"] # Provide a unique ID for the new document
+        new_document_ids=["studio_ghibli_doc_CRUD"]
     )
 
     new_collection = srsly.read_json(str(collection_path))
     assert len(new_collection) > old_collection_len
-    # The exact number of chunks (like 140) can be very specific and brittle.
-    # It's better to assert that the collection grew and that content from the new doc is searchable.
-
     # Optional: Verify new content is searchable
     results = RAG.search(index_name=miyazaki_index_name, query="Tokuma Shoten", k=1)
     assert len(results) > 0

--- a/tests/test_pretrained_loading.py
+++ b/tests/test_pretrained_loading.py
@@ -1,16 +1,102 @@
 import pytest
+import shutil
+from pathlib import Path
+from ragatouille import RAGPretrainedModel
+
+# Constants for tests
+PRETRAINED_MODEL_FOR_LOADING_TESTS = "colbert-ir/colbertv2.0" # Using a real, small model
+# Alternative for faster tests if available: "hf-internal-testing/tiny-bert-colbert" - but this might not work with ColBERT logic directly
+TEST_EXPERIMENT_LOADING = "ragatouille_loading_tests"
+
+@pytest.fixture(scope="session")
+def loading_test_index_root(tmp_path_factory):
+    """Creates a session-wide temporary root directory for indices created during loading tests."""
+    path = tmp_path_factory.mktemp("loading_tests_indices")
+    yield str(path)
+    shutil.rmtree(path, ignore_errors=True) # Clean up after all tests in session
+
+def test_from_pretrained_loads_model(loading_test_index_root):
+    """Tests if RAGPretrainedModel.from_pretrained successfully loads the underlying ColBERT model."""
+    rag_instance = RAGPretrainedModel.from_pretrained(
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS,
+        index_root=loading_test_index_root,
+        experiment_name=TEST_EXPERIMENT_LOADING,
+        verbose=0
+    )
+    assert isinstance(rag_instance, RAGPretrainedModel), "Should return a RAGPretrainedModel instance."
+    assert rag_instance.model is not None, "Internal ColBERT model should be initialized."
+    assert hasattr(rag_instance.model, 'inference_ckpt'), "ColBERT model should have an inference_ckpt."
+    assert rag_instance.model.inference_ckpt is not None, "inference_ckpt should be loaded."
+    assert rag_instance.model.base_pretrained_model_name_or_path == PRETRAINED_MODEL_FOR_LOADING_TESTS
+
+def test_from_index_loads_model_and_specific_index(loading_test_index_root):
+    """
+    Tests if RAGPretrainedModel.from_index can load a model and correctly
+    initialize with the specified index.
+    """
+    index_name_for_test = "my_loading_test_index"
+    documents_for_index = ["This is a test document for loading from index."]
+    doc_ids_for_index = ["test_doc_loader_01"]
+
+    # Step 1: Create an index to load from
+    rag_for_creation = RAGPretrainedModel.from_pretrained(
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS,
+        index_root=loading_test_index_root,
+        experiment_name=TEST_EXPERIMENT_LOADING,
+        verbose=0
+    )
+    created_index_path_str = rag_for_creation.index(
+        index_name=index_name_for_test,
+        documents=documents_for_index,
+        document_ids=doc_ids_for_index,
+        overwrite_index=True
+    )
+    created_index_path = Path(created_index_path_str)
+    assert created_index_path.exists(), "Index directory for loading test was not created."
+
+    # Step 2: Load from the created index
+    rag_loaded_from_index = RAGPretrainedModel.from_index(
+        index_path=str(created_index_path),
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS, # Crucial for new API
+        verbose=0
+    )
+
+    assert isinstance(rag_loaded_from_index, RAGPretrainedModel), "from_index should return RAGPretrainedModel."
+    assert rag_loaded_from_index.model is not None, "Internal ColBERT model should be initialized via from_index."
+    assert hasattr(rag_loaded_from_index.model, 'inference_ckpt'), "ColBERT model (from_index) should have inference_ckpt."
+    assert rag_loaded_from_index.model.inference_ckpt is not None, "inference_ckpt (from_index) should be loaded."
+
+    # Check if the ColBERT model correctly identifies the initially loaded index
+    # The 'initial_index_name' is set in ColBERT.__init__ if an index is loaded at startup.
+    # from_index in RAGPretrainedModel passes the inferred index name as 'initial_index_name'
+    # to from_pretrained, which then passes it to ColBERT.
+    assert rag_loaded_from_index.model.index_configs.get(index_name_for_test) is not None, \
+        f"Index '{index_name_for_test}' config not found in loaded model."
+    
+    # Verify the model's index_root and experiment_name are correctly set through from_index logic
+    expected_index_root = str(created_index_path.parent.parent.parent) # index_root/experiment/indexes/index_name
+    assert rag_loaded_from_index.model.index_root == expected_index_root
+    assert rag_loaded_from_index.model.experiment_name == TEST_EXPERIMENT_LOADING
 
 
-@pytest.mark.skip(reason="NotImplemented")
-def test_from_checkpoint():
-    pass
+    # Step 3: Perform a simple search to ensure the loaded index is active and usable
+    search_query = "test document"
+    results = rag_loaded_from_index.search(
+        index_name=index_name_for_test,
+        query=search_query,
+        k=1
+    )
+    assert isinstance(results, list), "Search should return a list."
+    if documents_for_index: # If we actually indexed something
+        assert len(results) > 0, "Search returned no results on a supposedly loaded index."
+        assert results[0]["document_id"] == doc_ids_for_index[0], "Search did not retrieve the correct document."
 
-
-@pytest.mark.skip(reason="NotImplemented")
-def test_from_index():
-    pass
-
-
-@pytest.mark.skip(reason="NotImplemented")
+@pytest.mark.skip(reason="Test intent unclear or needs refactoring for current API. Covered by other e2e search tests.")
 def test_searcher():
+    """
+    This test was originally skipped and its intent regarding 'searcher' properties
+    is not directly testable via RAGPretrainedModel's public API in a meaningful way
+    beyond what `test_search` in e2e tests or `test_from_index_loads_model_and_index` cover.
+    The internal `Searcher` object management is an implementation detail of `ColBERT` and `ModelIndex`.
+    """
     pass

--- a/tests/test_pretrained_loading.py
+++ b/tests/test_pretrained_loading.py
@@ -1,102 +1,16 @@
 import pytest
-import shutil
-from pathlib import Path
-from ragatouille import RAGPretrainedModel
-
-# Constants for tests
-PRETRAINED_MODEL_FOR_LOADING_TESTS = "colbert-ir/colbertv2.0" # Using a real, small model
-# Alternative for faster tests if available: "hf-internal-testing/tiny-bert-colbert" - but this might not work with ColBERT logic directly
-TEST_EXPERIMENT_LOADING = "ragatouille_loading_tests"
-
-@pytest.fixture(scope="session")
-def loading_test_index_root(tmp_path_factory):
-    """Creates a session-wide temporary root directory for indices created during loading tests."""
-    path = tmp_path_factory.mktemp("loading_tests_indices")
-    yield str(path)
-    shutil.rmtree(path, ignore_errors=True) # Clean up after all tests in session
-
-def test_from_pretrained_loads_model(loading_test_index_root):
-    """Tests if RAGPretrainedModel.from_pretrained successfully loads the underlying ColBERT model."""
-    rag_instance = RAGPretrainedModel.from_pretrained(
-        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS,
-        index_root=loading_test_index_root,
-        experiment_name=TEST_EXPERIMENT_LOADING,
-        verbose=0
-    )
-    assert isinstance(rag_instance, RAGPretrainedModel), "Should return a RAGPretrainedModel instance."
-    assert rag_instance.model is not None, "Internal ColBERT model should be initialized."
-    assert hasattr(rag_instance.model, 'inference_ckpt'), "ColBERT model should have an inference_ckpt."
-    assert rag_instance.model.inference_ckpt is not None, "inference_ckpt should be loaded."
-    assert rag_instance.model.base_pretrained_model_name_or_path == PRETRAINED_MODEL_FOR_LOADING_TESTS
-
-def test_from_index_loads_model_and_specific_index(loading_test_index_root):
-    """
-    Tests if RAGPretrainedModel.from_index can load a model and correctly
-    initialize with the specified index.
-    """
-    index_name_for_test = "my_loading_test_index"
-    documents_for_index = ["This is a test document for loading from index."]
-    doc_ids_for_index = ["test_doc_loader_01"]
-
-    # Step 1: Create an index to load from
-    rag_for_creation = RAGPretrainedModel.from_pretrained(
-        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS,
-        index_root=loading_test_index_root,
-        experiment_name=TEST_EXPERIMENT_LOADING,
-        verbose=0
-    )
-    created_index_path_str = rag_for_creation.index(
-        index_name=index_name_for_test,
-        documents=documents_for_index,
-        document_ids=doc_ids_for_index,
-        overwrite_index=True
-    )
-    created_index_path = Path(created_index_path_str)
-    assert created_index_path.exists(), "Index directory for loading test was not created."
-
-    # Step 2: Load from the created index
-    rag_loaded_from_index = RAGPretrainedModel.from_index(
-        index_path=str(created_index_path),
-        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS, # Crucial for new API
-        verbose=0
-    )
-
-    assert isinstance(rag_loaded_from_index, RAGPretrainedModel), "from_index should return RAGPretrainedModel."
-    assert rag_loaded_from_index.model is not None, "Internal ColBERT model should be initialized via from_index."
-    assert hasattr(rag_loaded_from_index.model, 'inference_ckpt'), "ColBERT model (from_index) should have inference_ckpt."
-    assert rag_loaded_from_index.model.inference_ckpt is not None, "inference_ckpt (from_index) should be loaded."
-
-    # Check if the ColBERT model correctly identifies the initially loaded index
-    # The 'initial_index_name' is set in ColBERT.__init__ if an index is loaded at startup.
-    # from_index in RAGPretrainedModel passes the inferred index name as 'initial_index_name'
-    # to from_pretrained, which then passes it to ColBERT.
-    assert rag_loaded_from_index.model.index_configs.get(index_name_for_test) is not None, \
-        f"Index '{index_name_for_test}' config not found in loaded model."
-    
-    # Verify the model's index_root and experiment_name are correctly set through from_index logic
-    expected_index_root = str(created_index_path.parent.parent.parent) # index_root/experiment/indexes/index_name
-    assert rag_loaded_from_index.model.index_root == expected_index_root
-    assert rag_loaded_from_index.model.experiment_name == TEST_EXPERIMENT_LOADING
 
 
-    # Step 3: Perform a simple search to ensure the loaded index is active and usable
-    search_query = "test document"
-    results = rag_loaded_from_index.search(
-        index_name=index_name_for_test,
-        query=search_query,
-        k=1
-    )
-    assert isinstance(results, list), "Search should return a list."
-    if documents_for_index: # If we actually indexed something
-        assert len(results) > 0, "Search returned no results on a supposedly loaded index."
-        assert results[0]["document_id"] == doc_ids_for_index[0], "Search did not retrieve the correct document."
+@pytest.mark.skip(reason="NotImplemented")
+def test_from_checkpoint():
+    pass
 
-@pytest.mark.skip(reason="Test intent unclear or needs refactoring for current API. Covered by other e2e search tests.")
+
+@pytest.mark.skip(reason="NotImplemented")
+def test_from_index():
+    pass
+
+
+@pytest.mark.skip(reason="NotImplemented")
 def test_searcher():
-    """
-    This test was originally skipped and its intent regarding 'searcher' properties
-    is not directly testable via RAGPretrainedModel's public API in a meaningful way
-    beyond what `test_search` in e2e tests or `test_from_index_loads_model_and_index` cover.
-    The internal `Searcher` object management is an implementation detail of `ColBERT` and `ModelIndex`.
-    """
     pass

--- a/tests/test_pretrained_optional_args.py
+++ b/tests/test_pretrained_optional_args.py
@@ -1,283 +1,374 @@
 import os
 import shutil
-from pathlib import Path
 
 import pytest
 import srsly
 
 from ragatouille import RAGPretrainedModel
 
-# Sample data for tests
-COLLECTION_SAMPLES = [
-    "Hayao Miyazaki is a Japanese animator, filmmaker, and manga artist. He co-founded Studio Ghibli.",
-    "Studio Ghibli, Inc. is a Japanese animation studio based in Koganei, Tokyo. Its mascot is Totoro.",
-    "Princess Mononoke is a 1997 Japanese animated epic historical fantasy film by Studio Ghibli.",
+# Original global sample data
+collection_samples = [
+    "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941) is a Japanese animator, filmmaker, and manga artist. A co-founder of Studio Ghibli, he has attained international acclaim as a masterful storyteller and creator of Japanese animated feature films, and is widely regarded as one of the most accomplished filmmakers in the history of animation.\nBorn in Tokyo City in the Empire of Japan, Miyazaki expressed interest in manga and animation from an early age, and he joined Toei Animation in 1963. During his early years at Toei Animation he worked as an in-between artist and later collaborated with director Isao Takahata. Notable films to which Miyazaki contributed at Toei include Doggie March and Gulliver's Travels Beyond the Moon. He provided key animation to other films at Toei, such as Puss in Boots and Animal Treasure Island, before moving to A-Pro in 1971, where he co-directed Lupin the Third Part I alongside Takahata. After moving to Zuiyō Eizō (later known as Nippon Animation) in 1973, Miyazaki worked as an animator on World Masterpiece Theater, and directed the television series Future Boy Conan (1978). He joined Tokyo Movie Shinsha in 1979 to direct his first feature film The Castle of Cagliostro as well as the television series Sherlock Hound. In the same period, he also began writing and illustrating the manga Nausicaä of the Valley of the Wind (1982–1994), and he also directed the 1984 film adaptation produced by Topcraft.\nMiyazaki co-founded Studio Ghibli in 1985. He directed numerous films with Ghibli, including Laputa: Castle in the Sky (1986), My Neighbor Totoro (1988), Kiki's Delivery Service (1989), and Porco Rosso (1992). The films were met with critical and commercial success in Japan. Miyazaki's film Princess Mononoke was the first animated film ever to win the Japan Academy Prize for Picture of the Year, and briefly became the highest-grossing film in Japan following its release in 1997; its distribution to the Western world greatly increased Ghibli's popularity and influence outside Japan. His 2001 film Spirited Away became the highest-grossing film in Japanese history, winning the Academy Award for Best Animated Feature, and is frequently ranked among the greatest films of the 21st century. Miyazaki's later films—Howl's Moving Castle (2004), Ponyo (2008), and The Wind Rises (2013)—also enjoyed critical and commercial success.",
+    "Studio Ghibli, Inc. (Japanese: 株式会社スタジオジブリ, Hepburn: Kabushiki gaisha Sutajio Jiburi) is a Japanese animation studio based in Koganei, Tokyo. It has a strong presence in the animation industry and has expanded its portfolio to include various media formats, such as short subjects, television commercials, and two television films. Their work has been well-received by audiences and recognized with numerous awards. Their mascot and most recognizable symbol, the character Totoro from the 1988 film My Neighbor Totoro, is a giant spirit inspired by raccoon dogs (tanuki) and cats (neko). Among the studio's highest-grossing films are Spirited Away (2001), Howl's Moving Castle (2004), and Ponyo (2008). Studio Ghibli was founded on June 15, 1985, by the directors Hayao Miyazaki and Isao Takahata and producer Toshio Suzuki, after acquiring Topcraft's assets. The studio has also collaborated with video game studios on the visual development of several games.Five of the studio's films are among the ten highest-grossing anime feature films made in Japan. Spirited Away is second, grossing 31.68 billion yen in Japan and over US$380 million worldwide, and Princess Mononoke is fourth, grossing 20.18 billion yen. Three of their films have won the Animage Grand Prix award, four have won the Japan Academy Prize for Animation of the Year, and five have received Academy Award nominations. Spirited Away won the 2002 Golden Bear and the 2003 Academy Award for Best Animated Feature.On August 3, 2014, Studio Ghibli temporarily suspended production following Miyazaki's retirement.",
 ]
 
-DOCUMENT_IDS_SAMPLES = ["miyazaki_bio", "ghibli_info", "mononoke_film"]
+document_ids_samples = ["miyazaki", "ghibli"]
 
-DOCUMENT_METADATAS_SAMPLES = [
-    {"entity": "person", "source": "wikipedia", "year": 1941},
-    {"entity": "organisation", "source": "wikipedia", "founded": 1985},
-    {"entity": "film", "source": "wikipedia", "release_year": 1997},
+document_metadatas_samples = [
+    {"entity": "person", "source": "wikipedia"},
+    {"entity": "organisation", "source": "wikipedia"},
 ]
 
-# Use a fixed model name for tests for consistency
-PRETRAINED_MODEL_NAME = "colbert-ir/colbertv2.0"
-TEST_EXPERIMENT_NAME = "ragatouille_test_suite_optional_args"
-
+PRETRAINED_MODEL_FOR_TESTS = "colbert-ir/colbertv2.0"
+DEFAULT_EXPERIMENT_NAME = "colbert" # To match original path structure
 
 @pytest.fixture(scope="session")
-def persistent_test_index_root(tmp_path_factory):
-    # Creates a temporary root directory for all indices for the test session
-    path = tmp_path_factory.mktemp("ragatouille_test_indices_root_optional_args")
+def persistent_temp_index_root(tmp_path_factory):
+    path = tmp_path_factory.mktemp("temp_test_indexes_optional_args")
     yield str(path)
-    # Cleanup after session
-    shutil.rmtree(path, ignore_errors=True)
+    # Cleanup is handled by pytest tmp_path_factory for session-scoped fixtures
 
-
-@pytest.fixture(scope="module")  # One RAG model instance per test module (this file)
-def rag_model_instance(persistent_test_index_root):
+@pytest.fixture(scope="session")
+def RAG_from_pretrained_model_fixture(persistent_temp_index_root):
+    # Pass experiment_name to maintain original path structure if tests relied on it
     return RAGPretrainedModel.from_pretrained(
-        PRETRAINED_MODEL_NAME,
-        index_root=persistent_test_index_root,
-        experiment_name=TEST_EXPERIMENT_NAME,
-        verbose=0  # Keep test output clean
+        PRETRAINED_MODEL_FOR_TESTS,
+        index_root=str(persistent_temp_index_root),
+        experiment_name=DEFAULT_EXPERIMENT_NAME,
+        verbose=0
     )
 
-
-# Parameterize test cases for different combinations of inputs to RAG.index()
-INDEX_CREATION_PARAMS = [
-    pytest.param(
-        {
-            "documents": COLLECTION_SAMPLES[:1],
-            "document_ids": None, # Test auto-generation
-            "document_metadatas": None,
-            "index_name_suffix": "no_opts_auto_ids",
-            "max_document_length": 128,
-        },
-        id="no_optional_args_auto_ids",
-    ),
-    pytest.param(
-        {
-            "documents": COLLECTION_SAMPLES[:1],
-            "document_ids": DOCUMENT_IDS_SAMPLES[:1],
-            "document_metadatas": None,
-            "index_name_suffix": "with_docid",
-            "max_document_length": 512, # Simulate no splitting
-        },
-        id="with_doc_ids_no_split",
-    ),
-    pytest.param(
-        {
-            "documents": COLLECTION_SAMPLES[:2],
-            "document_ids": DOCUMENT_IDS_SAMPLES[:2],
-            "document_metadatas": DOCUMENT_METADATAS_SAMPLES[:2],
-            "index_name_suffix": "with_docid_meta",
-            "max_document_length": 64, # Simulate splitting
-        },
-        id="with_doc_ids_metadata_split",
-    ),
-    pytest.param(
-        {
-            "documents": COLLECTION_SAMPLES,
-            "document_ids": DOCUMENT_IDS_SAMPLES,
-            "document_metadatas": DOCUMENT_METADATAS_SAMPLES,
-            "index_name_suffix": "all_docs_all_details",
-            "max_document_length": 128,
-        },
-        id="all_docs_all_details_split",
-    ),
-]
-
-
-@pytest.fixture(scope="function", params=INDEX_CREATION_PARAMS)
-def index_params_for_function(request, rag_model_instance):
-    # Generates a unique index name for each parameterized test function run
-    base_params = request.param.copy()
-    # Create a unique index name based on test name and params
-    # to ensure isolation even if tests run in parallel within the module (though pytest usually serializes by default)
-    unique_suffix = request.node.name.replace("test_", "").replace("[", "_").replace("]", "")
-    base_params["index_name"] = f"test_idx_{base_params['index_name_suffix']}_{unique_suffix}"
-
-    # Ensure document_ids are correctly handled for RAG.index()
-    # If document_ids is None in params, RAGPretrainedModel will auto-generate them.
-    # Store the effective document_ids used for assertion later.
-    if base_params["document_ids"] is None:
-        # RAGPretrainedModel generates UUIDs if None is passed.
-        # We can't know them in advance for assertion against pid_docid_map values exactly,
-        # but we can check counts and that metadata aligns if generated.
-        # For simplicity in this test, we will just ensure metadata isn't expected if IDs were None.
-        base_params["effective_document_ids_for_assertion"] = None
-    else:
-        base_params["effective_document_ids_for_assertion"] = base_params["document_ids"]
-
-    return base_params
-
-
-@pytest.fixture(scope="function")
-def created_index_data(rag_model_instance, index_params_for_function):
-    RAG = rag_model_instance
-    params = index_params_for_function # Renamed for clarity within this fixture
-    index_name = params["index_name"]
-
-    actual_index_path_str = RAG.index(
-        index_name=index_name,
-        documents=params["documents"],
-        document_ids=params["document_ids"], # Pass None if specified in params for auto-generation
-        document_metadatas=params["document_metadatas"],
-        max_document_length=params["max_document_length"],
-        overwrite_index=True # Crucial for test isolation
+@pytest.fixture(scope="session")
+def index_path_fixture_session(persistent_temp_index_root, index_creation_inputs_session):
+    # Construct path as it was originally, assuming experiment_name="colbert"
+    # index_root / experiment_name / "indexes" / index_name
+    index_path = os.path.join(
+        str(persistent_temp_index_root),
+        DEFAULT_EXPERIMENT_NAME, # "colbert"
+        "indexes",
+        index_creation_inputs_session["index_name"],
     )
-    yield {
-        "index_name": index_name,
-        "index_path_str": actual_index_path_str,
-        "params_used": params # Contains effective_document_ids_for_assertion
-    }
-    # Optional: RAG.delete_index(index_name) if it exists, or rely on session cleanup of root.
+    return str(index_path)
 
+@pytest.fixture(scope="session")
+def collection_path_fixture_session(index_path_fixture_session):
+    collection_path = os.path.join(index_path_fixture_session, "collection.json")
+    return str(collection_path)
 
-def get_full_index_path_obj(persistent_test_index_root, index_name):
-    return Path(persistent_test_index_root) / TEST_EXPERIMENT_NAME / "indexes" / index_name
+@pytest.fixture(scope="session")
+def document_metadata_path_fixture_session(index_path_fixture_session):
+    document_metadata_path = os.path.join(index_path_fixture_session, "docid_metadata_map.json")
+    return str(document_metadata_path)
 
+@pytest.fixture(scope="session")
+def pid_docid_map_path_fixture_session(index_path_fixture_session):
+    pid_docid_map_path = os.path.join(index_path_fixture_session, "pid_docid_map.json")
+    return str(pid_docid_map_path)
 
-def test_index_creation_and_structure(created_index_data, persistent_test_index_root):
-    index_name = created_index_data["index_name"]
-    params_used = created_index_data["params_used"]
-    full_path = get_full_index_path_obj(persistent_test_index_root, index_name)
+# Renamed original fixture to avoid conflict if used directly by tests
+# These are now session-scoped to match the dependent fixtures.
+@pytest.fixture(
+    scope="session",
+    params=[
+        {
+            "collection": collection_samples, # Use original variable name for data
+            "index_name": "no_optional_args",
+            "split_documents": False,
+        },
+        {
+            "collection": collection_samples,
+            "document_ids": document_ids_samples, # Use original variable name
+            "index_name": "with_docid",
+            "split_documents": False,
+        },
+        {
+            "collection": collection_samples,
+            "document_metadatas": document_metadatas_samples, # Use original variable name
+            "index_name": "with_metadata",
+            "split_documents": False,
+        },
+        {
+            "collection": collection_samples,
+            "index_name": "with_split",
+            "split_documents": True,
+        },
+        {
+            "collection": collection_samples,
+            "document_ids": document_ids_samples,
+            "document_metadatas": document_metadatas_samples,
+            "index_name": "with_docid_metadata",
+            "split_documents": False,
+        },
+        {
+            "collection": collection_samples,
+            "document_ids": document_ids_samples,
+            "index_name": "with_docid_split",
+            "split_documents": True,
+        },
+        {
+            "collection": collection_samples,
+            "document_metadatas": document_metadatas_samples,
+            "index_name": "with_metadata_split",
+            "split_documents": True,
+        },
+        {
+            "collection": collection_samples,
+            "document_ids": document_ids_samples,
+            "document_metadatas": document_metadatas_samples,
+            "index_name": "with_docid_metadata_split",
+            "split_documents": True,
+        },
+    ],
+    ids=[
+        "No optional arguments",
+        "With document IDs",
+        "With metadata",
+        "With document splitting",
+        "With document IDs and metadata",
+        "With document IDs and splitting",
+        "With metadata and splitting",
+        "With document IDs, metadata, and splitting",
+    ],
+)
+def index_creation_inputs_session(request):
+    # This provides the raw parameters for each test case
+    return request.param
 
-    assert full_path.exists(), f"Index directory {full_path} was not created."
-    assert (full_path / "collection.json").exists(), "collection.json missing."
-    assert (full_path / "pid_docid_map.json").exists(), "pid_docid_map.json missing."
+@pytest.fixture(scope="session")
+def create_index_session(RAG_from_pretrained_model_fixture, index_creation_inputs_session):
+    api_call_params = index_creation_inputs_session.copy()
 
-    if params_used.get("document_metadatas"):
-        assert (full_path / "docid_metadata_map.json").exists(), "docid_metadata_map.json missing when metadata provided."
+    if "collection" in api_call_params:
+        api_call_params["documents"] = api_call_params.pop("collection")
+
+    split_docs = api_call_params.pop("split_documents", False) # Default to False if not present
+    if split_docs:
+        api_call_params["max_document_length"] = 256 # Default for splitting
     else:
-        assert not (full_path / "docid_metadata_map.json").exists(), "docid_metadata_map.json exists when no metadata provided."
+        api_call_params["max_document_length"] = 1_000_000 # Effectively no splitting
 
-    pid_docid_map_data = srsly.read_json(str(full_path / "pid_docid_map.json"))
+    # Ensure 'document_ids' and 'document_metadatas' are present if needed, or pass None
+    api_call_params.setdefault("document_ids", None)
+    api_call_params.setdefault("document_metadatas", None)
+
+    # overwrite_index=True ensures a clean state for each parameterization if run independently
+    # but since this is session scoped and parameterized, this might overwrite for subsequent params.
+    # For strict adherence to "minimal change", we keep the original logic where overwrite
+    # policy is implicitly handled by ColBERT (default "reuse").
+    # If tests need pristine state per param set, they'd need function scope.
+    # Given the original was session-scoped, let's assume sequential execution of params or reuse is fine.
+    api_call_params["overwrite_index"] = True
+
+
+    index_path = RAG_from_pretrained_model_fixture.index(**api_call_params)
+    return index_path
+
+# This fixture ensures that `index_creation_inputs_session` has `document_ids` populated
+# for tests that rely on it later (like metadata checks).
+@pytest.fixture(scope="session", autouse=True)
+def populate_docids_in_inputs_session(
+    create_index_session, # Ensures index is created first
+    index_creation_inputs_session, # The specific parameters for current session iteration
+    pid_docid_map_path_fixture_session, # Path to the pid_docid_map.json for this iteration
+):
+    # If document_ids were not initially provided for this parameter set
+    if "document_ids" not in index_creation_inputs_session or index_creation_inputs_session["document_ids"] is None:
+        # And if metadata was provided (implying IDs are important for mapping)
+        # Or if we just want to ensure IDs are available for later tests like delete
+        pid_docid_map_data = srsly.read_json(pid_docid_map_path_fixture_session)
+        # Extract unique document IDs from the map
+        seen_ids = set()
+        # The PIDs are integers, values are the DocIDs.
+        # RAGPretrainedModel ensures these are strings (UUIDs if auto-generated)
+        effective_doc_ids = [
+            str(x) # Ensure string type consistent with how RAGPretrainedModel handles it
+            for x in list(pid_docid_map_data.values())
+            if not (str(x) in seen_ids or seen_ids.add(str(x))) # Unique doc_ids
+        ]
+        index_creation_inputs_session["document_ids"] = effective_doc_ids
+        # If metadatas were provided but IDs were not, this step is crucial
+        # for aligning them for later assertions.
+        # However, this might be tricky if the number of auto-generated IDs
+        # doesn't match the number of metadatas provided initially.
+        # The original test assumed this alignment; RAGPretrainedModel now requires
+        # document_ids if document_metadatas is provided.
+        # If document_ids was None but document_metadatas was not, an error should occur earlier.
+        # This fixture primarily helps when both were None, or only collection was given.
+
+
+# Tests now use the session-scoped fixtures.
+# Each test function will run ONCE per parameter set defined in `index_creation_inputs_session`.
+# The state of the index will persist across these test functions for a given parameter set.
+
+def test_index_creation(create_index_session): # Uses the created index for the current param set
+    assert os.path.exists(create_index_session), "Index path should exist."
+
+def test_collection_creation(collection_path_fixture_session): # Path for current param set
+    assert os.path.exists(collection_path_fixture_session)
+    collection_data = srsly.read_json(collection_path_fixture_session)
+    assert isinstance(collection_data, list)
+
+def test_pid_docid_map_creation(pid_docid_map_path_fixture_session): # Path for current param set
+    assert os.path.exists(pid_docid_map_path_fixture_session)
+    pid_docid_map_data = srsly.read_json(pid_docid_map_path_fixture_session)
     assert isinstance(pid_docid_map_data, dict)
-    
-    # Check that number of passages (PIDs) is reasonable
-    # If max_document_length is small, expect more passages than original documents
-    if params_used["max_document_length"] < 200 and len(params_used["documents"]) > 0 : # Rough check for splitting
-        assert len(pid_docid_map_data) >= len(params_used["documents"]), "Splitting should result in more or equal passages than documents"
-    elif len(params_used["documents"]) > 0:
-         assert len(pid_docid_map_data) == len(params_used["documents"]), "No splitting should result in equal passages and documents"
+
+def test_document_metadata_creation(
+    index_creation_inputs_session, document_metadata_path_fixture_session
+):
+    if "document_metadatas" in index_creation_inputs_session and index_creation_inputs_session["document_metadatas"] is not None:
+        assert os.path.exists(document_metadata_path_fixture_session)
+        document_metadata_dict = srsly.read_json(document_metadata_path_fixture_session)
+
+        # Ensure document_ids were populated if metadatas are to be checked
+        assert "document_ids" in index_creation_inputs_session and index_creation_inputs_session["document_ids"] is not None, \
+            "document_ids must be available in inputs to check metadata mapping."
+
+        assert set(document_metadata_dict.keys()) == set(index_creation_inputs_session["document_ids"])
+        for doc_id, metadata in document_metadata_dict.items():
+            idx = index_creation_inputs_session["document_ids"].index(doc_id)
+            assert metadata == index_creation_inputs_session["document_metadatas"][idx]
+    else:
+        assert not os.path.exists(document_metadata_path_fixture_session)
+
+def test_document_metadata_returned_in_search_results(
+    RAG_from_pretrained_model_fixture, index_creation_inputs_session, index_path_fixture_session, persistent_temp_index_root
+):
+    # Use from_index to get a fresh RAG instance for searching this specific index parameterization
+    # This ensures that the RAG instance is configured specifically for the index being tested.
+    # The pretrained_model_name_or_path is crucial for the new API.
+    RAG = RAGPretrainedModel.from_index(
+        index_path=index_path_fixture_session,
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_TESTS,
+        index_root=str(persistent_temp_index_root),
+        verbose=0
+    )
+
+    results = RAG.search(
+        query="when was miyazaki born", # A generic query
+        index_name=index_creation_inputs_session["index_name"]
+    )
+
+    if "document_metadatas" in index_creation_inputs_session and index_creation_inputs_session["document_metadatas"] is not None:
+        assert "document_ids" in index_creation_inputs_session and index_creation_inputs_session["document_ids"] is not None, \
+            "document_ids must be available in inputs to check metadata in search results."
+        for result in results:
+            assert "document_metadata" in result
+            doc_id = result["document_id"]
+            # This assumes doc_id from search result will be in the original list
+            # which is true if IDs were provided or correctly inferred.
+            if doc_id in index_creation_inputs_session["document_ids"]:
+                 idx = index_creation_inputs_session["document_ids"].index(doc_id)
+                 expected_metadata = index_creation_inputs_session["document_metadatas"][idx]
+                 assert result["document_metadata"] == expected_metadata
+    else:
+        for result in results:
+            assert "document_metadata" not in result
 
 
-    if params_used.get("effective_document_ids_for_assertion"):
-        provided_doc_ids_set = set(params_used["effective_document_ids_for_assertion"])
-        mapped_doc_ids_set = set(pid_docid_map_data.values())
-        assert provided_doc_ids_set == mapped_doc_ids_set, "Mismatch between provided document_ids and those in pid_docid_map."
+def test_add_to_existing_index(
+    index_creation_inputs_session,
+    index_path_fixture_session, # Path to the specific index for this param set
+    pid_docid_map_path_fixture_session,
+    document_metadata_path_fixture_session,
+    persistent_temp_index_root
+):
+    # Instantiate RAG using from_index to ensure it's targeting the correct index path and root
+    RAG = RAGPretrainedModel.from_index(
+        index_path=index_path_fixture_session,
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_TESTS,
+        index_root=str(persistent_temp_index_root),
+        verbose=0
+    )
 
+    # This relies on populate_docids_in_inputs_session to have run
+    existing_doc_ids = index_creation_inputs_session.get("document_ids", [])
 
-def test_search_results_and_metadata(rag_model_instance, created_index_data):
-    RAG = rag_model_instance
-    index_name = created_index_data["index_name"]
-    params_used = created_index_data["params_used"]
-
-    query = "Hayao Miyazaki Ghibli" # A general query likely to hit sample data
-    results = RAG.search(index_name=index_name, query=query, k=1)
-
-    assert isinstance(results, list)
-    if params_used["documents"]:
-        # Results can be empty if k=0 or no match, so check len >= 0
-        assert len(results) <= 1, "Search with k=1 should return at most 1 result."
-        if results:
-            result = results[0]
-            assert "content" in result
-            assert "score" in result
-            assert "rank" in result
-            assert "document_id" in result
-
-            if params_used.get("document_metadatas") and params_used.get("effective_document_ids_for_assertion"):
-                assert "document_metadata" in result, "document_metadata missing in search result."
-                retrieved_doc_id = result["document_id"]
-                try:
-                    original_idx = params_used["effective_document_ids_for_assertion"].index(retrieved_doc_id)
-                    expected_metadata = params_used["document_metadatas"][original_idx]
-                    assert result["document_metadata"] == expected_metadata, "Mismatch in returned document metadata."
-                except ValueError:
-                    # This can happen if the retrieved_doc_id was auto-generated and not in our effective_document_ids_for_assertion
-                    # This part of the check is only fully valid if document_ids were explicitly provided.
-                    if params_used["document_ids"] is not None: # Only fail if we expected to find it
-                        pytest.fail(f"Retrieved document_id {retrieved_doc_id} not in original document_ids for test.")
-            else:
-                assert "document_metadata" not in result, "document_metadata present when it was not indexed."
-    else: # No documents were indexed
-        assert len(results) == 0
-
-
-def test_add_to_existing_index(rag_model_instance, created_index_data, persistent_test_index_root):
-    RAG = rag_model_instance
-    index_name = created_index_data["index_name"]
-    full_index_dir_path = get_full_index_path_obj(persistent_test_index_root, index_name)
-    collection_file_path = full_index_dir_path / "collection.json"
-    pid_docid_map_file_path = full_index_dir_path / "pid_docid_map.json"
-    docid_metadata_map_file_path = full_index_dir_path / "docid_metadata_map.json"
-
-    initial_collection_len = len(srsly.read_json(str(collection_file_path)))
-
-    new_docs_to_add = ["Toei Animation is another famous Japanese animation studio."]
-    new_doc_ids_to_add = ["toei_animation_info_add_test"]
-    new_doc_metadatas_to_add = [{"entity": "organisation", "source": "test_add_to_index"}]
+    new_doc_ids = ["mononoke_added", "sabaku_no_tami_added"]
+    new_docs_to_add = [
+        "Princess Mononoke is an epic film.",
+        "People of the Desert is a manga by Miyazaki.",
+    ]
+    new_doc_metadata_to_add = [
+        {"entity": "film", "source": "test_add"},
+        {"entity": "manga", "source": "test_add"},
+    ]
 
     RAG.add_to_index(
-        index_name=index_name,
-        new_documents=new_docs_to_add,
-        new_document_ids=new_doc_ids_to_add,
-        new_document_metadatas=new_doc_metadatas_to_add,
+        index_name=index_creation_inputs_session["index_name"],
+        new_documents=new_docs_to_add, # API change: new_collection -> new_documents
+        new_document_ids=new_doc_ids,
+        new_document_metadatas=new_doc_metadata_to_add,
     )
 
-    updated_collection = srsly.read_json(str(collection_file_path))
-    assert len(updated_collection) > initial_collection_len
+    pid_docid_map_data_after_add = srsly.read_json(pid_docid_map_path_fixture_session)
+    doc_ids_in_map_after_add = set(list(pid_docid_map_data_after_add.values()))
 
-    updated_pid_docid_map = srsly.read_json(str(pid_docid_map_file_path))
-    assert new_doc_ids_to_add[0] in updated_pid_docid_map.values()
+    # Check for new docs
+    for new_doc_id in new_doc_ids:
+        assert new_doc_id in doc_ids_in_map_after_add
 
-    if docid_metadata_map_file_path.exists() or new_doc_metadatas_to_add: # File may be created if it didn't exist but new metadata is added
-        # Wait for file system to catch up if needed, though srsly should handle it.
-        if not docid_metadata_map_file_path.exists() and new_doc_metadatas_to_add:
-            import time; time.sleep(0.1) # Small delay, usually not needed
+    # Check existing docs are still there
+    for existing_doc_id in existing_doc_ids:
+        assert existing_doc_id in doc_ids_in_map_after_add
 
-        if docid_metadata_map_file_path.exists():
-            updated_docid_metadata_map = srsly.read_json(str(docid_metadata_map_file_path))
-            assert new_doc_ids_to_add[0] in updated_docid_metadata_map
-            assert updated_docid_metadata_map[new_doc_ids_to_add[0]] == new_doc_metadatas_to_add[0]
-    
-    results_for_new = RAG.search(index_name=index_name, query="Toei Animation studio", k=3)
-    found_new_doc_in_search = any(res.get("document_id") == new_doc_ids_to_add[0] for res in results_for_new)
-    assert found_new_doc_in_search, "Newly added document not found in search results."
+    if os.path.exists(document_metadata_path_fixture_session):
+        doc_metadata_dict_after_add = srsly.read_json(document_metadata_path_fixture_session)
+        for new_doc_id in new_doc_ids:
+            assert new_doc_id in doc_metadata_dict_after_add
+        if "document_metadatas" in index_creation_inputs_session and index_creation_inputs_session["document_metadatas"] is not None:
+            for existing_doc_id in existing_doc_ids:
+                 assert existing_doc_id in doc_metadata_dict_after_add
+
+def test_delete_from_index(
+    index_creation_inputs_session,
+    index_path_fixture_session, # Path to the specific index
+    pid_docid_map_path_fixture_session,
+    document_metadata_path_fixture_session,
+    persistent_temp_index_root
+):
+    # Instantiate RAG using from_index to ensure it's targeting the correct index path and root
+    RAG = RAGPretrainedModel.from_index(
+        index_path=index_path_fixture_session,
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_TESTS,
+        index_root=str(persistent_temp_index_root),
+        verbose=0
+    )
+
+    # This test assumes 'document_ids' were populated by populate_docids_in_inputs_session
+    # or were part of the original index_creation_inputs_session.
+    if not index_creation_inputs_session.get("document_ids"):
+        pytest.skip("Cannot run delete test if no document_ids are defined for the index.")
+
+    # To ensure this test doesn't interfere with subsequent parameterizations using the same files
+    # if not re-instanced with from_index, we might need function-scoped RAG instances or careful state management.
+    # However, the original structure was session-scoped. We proceed by trying to delete one of the *original* IDs.
+    # This assumes the add_to_index test might have run before.
+
+    doc_ids_before_delete_set = set(srsly.read_json(pid_docid_map_path_fixture_session).values())
+
+    # Pick an ID to delete that was part of the original set for this param, if any
+    # Or, if add_to_index ran, it could be one of those. Let's try to delete one of the "added" ones if present.
+    id_to_delete = "mononoke_added" # From test_add_to_existing_index
+    if id_to_delete not in doc_ids_before_delete_set:
+        # If the "added" ID isn't there (e.g. add test skipped or failed), try an original one
+        if index_creation_inputs_session["document_ids"]:
+            id_to_delete = index_creation_inputs_session["document_ids"][0]
+        else:
+            pytest.skip("No clear ID to delete for this test run.")
 
 
-def test_delete_from_index(rag_model_instance, created_index_data, persistent_test_index_root):
-    RAG = rag_model_instance
-    index_name = created_index_data["index_name"]
-    params_used = created_index_data["params_used"]
-    
-    # This test can only meaningfully run if specific document_ids were used for creation
-    if not params_used.get("effective_document_ids_for_assertion"):
-        pytest.skip("Skipping delete test as no explicit document_ids were used for this index setup.")
+    RAG.delete_from_index(
+        index_name=index_creation_inputs_session["index_name"],
+        document_ids=[id_to_delete], # API change: expects List[str]
+    )
 
-    doc_id_to_delete = params_used["effective_document_ids_for_assertion"][0]
-    content_of_deleted_doc = params_used["documents"][0] # Get content to search for it later
+    pid_docid_map_data_after_delete = srsly.read_json(pid_docid_map_path_fixture_session)
+    doc_ids_in_map_after_delete = set(list(pid_docid_map_data_after_delete.values()))
 
-    full_index_dir_path = get_full_index_path_obj(persistent_test_index_root, index_name)
-    pid_docid_map_file_path = full_index_dir_path / "pid_docid_map.json"
-    docid_metadata_map_file_path = full_index_dir_path / "docid_metadata_map.json"
+    assert id_to_delete not in doc_ids_in_map_after_delete
 
-    RAG.delete_from_index(index_name=index_name, document_ids=[doc_id_to_delete])
-
-    updated_pid_docid_map = srsly.read_json(str(pid_docid_map_file_path))
-    assert doc_id_to_delete not in updated_pid_docid_map.values()
-
-    if params_used.get("document_metadatas"):
-        if docid_metadata_map_file_path.exists(): # File might be deleted if all entries removed
-            updated_docid_metadata_map = srsly.read_json(str(docid_metadata_map_file_path))
-            assert doc_id_to_delete not in updated_docid_metadata_map
-            
-    # Try to search for content of the deleted document
-    results_after_delete = RAG.search(index_name=index_name, query=content_of_deleted_doc, k=5)
-    found_deleted_id_in_results = any(res.get("document_id") == doc_id_to_delete for res in results_after_delete)
-    assert not found_deleted_id_in_results, f"Document ID {doc_id_to_delete} was found in search results after deletion."
+    if "document_metadatas" in index_creation_inputs_session and index_creation_inputs_session["document_metadatas"] is not None:
+        if os.path.exists(document_metadata_path_fixture_session): # Check if metadata file still exists
+            doc_metadata_dict_after_delete = srsly.read_json(document_metadata_path_fixture_session)
+            assert id_to_delete not in doc_metadata_dict_after_delete

--- a/tests/test_pretrained_optional_args.py
+++ b/tests/test_pretrained_optional_args.py
@@ -65,25 +65,23 @@ def pid_docid_map_path_fixture_session(index_path_fixture_session):
     pid_docid_map_path = os.path.join(index_path_fixture_session, "pid_docid_map.json")
     return str(pid_docid_map_path)
 
-# Renamed original fixture to avoid conflict if used directly by tests
-# These are now session-scoped to match the dependent fixtures.
 @pytest.fixture(
     scope="session",
     params=[
         {
-            "collection": collection_samples, # Use original variable name for data
+            "collection": collection_samples,
             "index_name": "no_optional_args",
             "split_documents": False,
         },
         {
             "collection": collection_samples,
-            "document_ids": document_ids_samples, # Use original variable name
+            "document_ids": document_ids_samples,
             "index_name": "with_docid",
             "split_documents": False,
         },
         {
             "collection": collection_samples,
-            "document_metadatas": document_metadatas_samples, # Use original variable name
+            "document_metadatas": document_metadatas_samples,
             "index_name": "with_metadata",
             "split_documents": False,
         },
@@ -145,7 +143,7 @@ def create_index_session(RAG_from_pretrained_model_fixture, index_creation_input
     if split_docs:
         api_call_params["max_document_length"] = 256 # Default for splitting
     else:
-        api_call_params["max_document_length"] = 1_000_000 # Effectively no splitting
+        api_call_params["max_document_length"] = 512 # Cap at model's max sequence length
 
     # Ensure 'document_ids' and 'document_metadatas' are present if needed, or pass None
     api_call_params.setdefault("document_ids", None)
@@ -200,7 +198,7 @@ def populate_docids_in_inputs_session(
 # Each test function will run ONCE per parameter set defined in `index_creation_inputs_session`.
 # The state of the index will persist across these test functions for a given parameter set.
 
-def test_index_creation(create_index_session): # Uses the created index for the current param set
+def test_index_creation(create_index_session):
     assert os.path.exists(create_index_session), "Index path should exist."
 
 def test_collection_creation(collection_path_fixture_session): # Path for current param set

--- a/tests/test_trainer_loading.py
+++ b/tests/test_trainer_loading.py
@@ -11,7 +11,7 @@ def test_finetune(tmp_path):
         pretrained_model_name="colbert-ir/colbertv2.0",
         language_code="en",
     )
-    trainer_config = trainer.model.config
+    trainer_config = trainer.model.base_model_config
 
     assert ColBERTConfig() != trainer_config
     assert trainer_config.query_token == "[Q]"
@@ -33,7 +33,7 @@ def test_raw_model(tmp_path):
         pretrained_model_name="bert-base-uncased",
         language_code="en",
     )
-    trainer_config = trainer.model.config
+    trainer_config = trainer.model.base_model_config
 
     default_config = ColBERTConfig()
 

--- a/tests/test_trainer_loading.py
+++ b/tests/test_trainer_loading.py
@@ -1,9 +1,10 @@
+import pytest
 from colbert.infra import ColBERTConfig
 
 from ragatouille import RAGTrainer
 
 
-def test_finetune():
+def test_finetune(tmp_path):
     """Ensure that the initially loaded config is the one from the pretrained model."""
     trainer = RAGTrainer(
         model_name="test",
@@ -25,7 +26,7 @@ def test_finetune():
     assert trainer_config.name == "kldR2.nway64.ib"
 
 
-def test_raw_model():
+def test_raw_model(tmp_path):
     """Ensure that the default ColBERT configuration is properly loaded when initialising from a BERT-like model"""  # noqa: E501
     trainer = RAGTrainer(
         model_name="test",

--- a/uv.lock
+++ b/uv.lock
@@ -604,6 +604,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1287,6 +1296,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1398,6 +1416,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
 name = "pylate"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1418,6 +1445,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/46/67de1d7a65412aa1c896e6b280829b70b57d203fadae6859b690006b8e0a/pypdf-5.6.0.tar.gz", hash = "sha256:a4b6538b77fc796622000db7127e4e58039ec5e6afd292f8e9bf42e2e985a749", size = 5023749, upload-time = "2025-06-01T12:19:40.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/8b/dc3a72d98c22be7a4cbd664ad14c5a3e6295c2dbdf572865ed61e24b5e38/pypdf-5.6.0-py3-none-any.whl", hash = "sha256:ca6bf446bfb0a2d8d71d6d6bb860798d864c36a29b3d9ae8d7fc7958c59f88e7", size = 304208, upload-time = "2025-06-01T12:19:38.003Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
 ]
 
 [[package]]
@@ -1479,6 +1522,7 @@ dependencies = [
     { name = "llama-index" },
     { name = "onnx" },
     { name = "psutil" },
+    { name = "pytest" },
     { name = "sentence-transformers" },
     { name = "setuptools" },
     { name = "srsly" },
@@ -1491,6 +1535,7 @@ all = [
     { name = "batched" },
     { name = "fastapi" },
     { name = "llama-index" },
+    { name = "pytest" },
     { name = "rerankers" },
     { name = "uvicorn" },
     { name = "voyager" },
@@ -1498,6 +1543,7 @@ all = [
 api = [
     { name = "batched" },
     { name = "fastapi" },
+    { name = "pytest" },
     { name = "uvicorn" },
 ]
 train = [
@@ -1521,6 +1567,9 @@ requires-dist = [
     { name = "onnx" },
     { name = "psutil" },
     { name = "pylate", marker = "extra == 'train'" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest", marker = "extra == 'all'" },
+    { name = "pytest", marker = "extra == 'api'" },
     { name = "rerankers", marker = "extra == 'all'" },
     { name = "rerankers", marker = "extra == 'train'" },
     { name = "sentence-transformers" },


### PR DESCRIPTION
This PR introduces the model-index relationship to be 1:1 for 1:n, in case one wants to segment indices by company or document type or whatever. This is very useful because it does not load the model to memory for each index and instead it loads it 1 time and allows the possibility to switch indices. It also adds a server implementation in FastAPI to create and update indices.